### PR TITLE
Increase log url size.

### DIFF
--- a/BlazarData/src/main/resources/schema.sql
+++ b/BlazarData/src/main/resources/schema.sql
@@ -32,7 +32,7 @@ CREATE TABLE `builds` (
   `startTimestamp` bigint(20) unsigned,
   `endTimestamp` bigint(20) unsigned,
   `sha` char(40),
-  `log` varchar(250),
+  `log` varchar(2048),
   PRIMARY KEY (`id`),
   UNIQUE INDEX (`moduleId`, `buildNumber`)
 ) ENGINE=InnoDB ROW_FORMAT=COMPRESSED KEY_BLOCK_SIZE=8 DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Its easy for a singularity mesos ID to push the log url to over 250 chars. Bumped the size to fit our urls.