### PR TITLE
Create taskId field for executor to report singularity task id into

### DIFF
--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/Build.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/Build.java
@@ -32,6 +32,7 @@ public class Build {
   @StoredAsJson
   private final Optional<CommitInfo> commitInfo;
   private final Optional<String> log;
+  private final Optional<String> taskId;
   @StoredAsJson
   private final Optional<BuildConfig> buildConfig;
   @StoredAsJson
@@ -47,6 +48,7 @@ public class Build {
                @JsonProperty("sha") Optional<String> sha,
                @JsonProperty("commitInfo") Optional<CommitInfo> commitInfo,
                @JsonProperty("log") Optional<String> log,
+               @JsonProperty("taskId") Optional<String> taskId,
                @JsonProperty("buildConfig") Optional<BuildConfig> buildConfig,
                @JsonProperty("resolvedConfig") Optional<BuildConfig> resolvedConfig) {
     this.id = id;
@@ -56,6 +58,7 @@ public class Build {
     this.startTimestamp = startTimestamp;
     this.endTimestamp = endTimestamp;
     this.sha = sha;
+    this.taskId = taskId;
     this.commitInfo = com.google.common.base.Objects.firstNonNull(commitInfo, Optional.<CommitInfo>absent());
     this.log = log;
     this.buildConfig = buildConfig;
@@ -68,7 +71,7 @@ public class Build {
     Optional<CommitInfo> commitInfo = Optional.absent();
     Optional<BuildConfig> config = Optional.absent();
 
-    return new Build(absentLong, module.getId().get(), buildNumber, State.QUEUED, absentLong, absentLong, absentString, commitInfo, absentString, config, config);
+    return new Build(absentLong, module.getId().get(), buildNumber, State.QUEUED, absentLong, absentLong, absentString, commitInfo, absentString, absentString, config, config);
   }
 
   public Optional<Long> getId() {
@@ -107,6 +110,10 @@ public class Build {
     return log;
   }
 
+  public Optional<String> getTaskId() {
+    return taskId;
+  }
+
   public Optional<BuildConfig> getBuildConfig() {
     return buildConfig;
   }
@@ -116,36 +123,36 @@ public class Build {
   }
 
   public Build withId(long id) {
-    return new Build(Optional.of(id), moduleId, buildNumber, state, startTimestamp, endTimestamp, sha, commitInfo, log, buildConfig, resolvedConfig);
+    return new Build(Optional.of(id), moduleId, buildNumber, state, startTimestamp, endTimestamp, sha, commitInfo, log, taskId, buildConfig, resolvedConfig);
   }
 
   public Build withCommitInfo(CommitInfo commitInfo) {
     Optional<String> sha = Optional.of(commitInfo.getCurrent().getId());
-    return new Build(id, moduleId, buildNumber, state, startTimestamp, endTimestamp, sha, Optional.of(commitInfo), log, buildConfig, resolvedConfig);
+    return new Build(id, moduleId, buildNumber, state, startTimestamp, endTimestamp, sha, Optional.of(commitInfo), log, taskId, buildConfig, resolvedConfig);
   }
 
   public Build withState(State state) {
-    return new Build(id, moduleId, buildNumber, state, startTimestamp, endTimestamp, sha, commitInfo, log, buildConfig, resolvedConfig);
+    return new Build(id, moduleId, buildNumber, state, startTimestamp, endTimestamp, sha, commitInfo, log, taskId, buildConfig, resolvedConfig);
   }
 
   public Build withStartTimestamp(long startTimestamp) {
-    return new Build(id, moduleId, buildNumber, state, Optional.of(startTimestamp), endTimestamp, sha, commitInfo, log, buildConfig, resolvedConfig);
+    return new Build(id, moduleId, buildNumber, state, Optional.of(startTimestamp), endTimestamp, sha, commitInfo, log, taskId, buildConfig, resolvedConfig);
   }
 
   public Build withEndTimestamp(long endTimestamp) {
-    return new Build(id, moduleId, buildNumber, state, startTimestamp, Optional.of(endTimestamp), sha, commitInfo, log, buildConfig, resolvedConfig);
+    return new Build(id, moduleId, buildNumber, state, startTimestamp, Optional.of(endTimestamp), sha, commitInfo, log, taskId, buildConfig, resolvedConfig);
   }
 
   public Build withLog(String log) {
-    return new Build(id, moduleId, buildNumber, state, startTimestamp, endTimestamp, sha, commitInfo, Optional.of(log), buildConfig, resolvedConfig);
+    return new Build(id, moduleId, buildNumber, state, startTimestamp, endTimestamp, sha, commitInfo, Optional.of(log), taskId, buildConfig, resolvedConfig);
   }
 
   public Build withBuildConfig(BuildConfig buildConfig) {
-    return new Build(id, moduleId, buildNumber, state, startTimestamp, endTimestamp, sha, commitInfo, log, Optional.of(buildConfig), resolvedConfig);
+    return new Build(id, moduleId, buildNumber, state, startTimestamp, endTimestamp, sha, commitInfo, log, taskId, Optional.of(buildConfig), resolvedConfig);
   }
 
   public Build withResolvedConfig(BuildConfig resolvedConfig) {
-    return new Build(id, moduleId, buildNumber, state, startTimestamp, endTimestamp, sha, commitInfo, log, buildConfig, Optional.of(resolvedConfig));
+    return new Build(id, moduleId, buildNumber, state, startTimestamp, endTimestamp, sha, commitInfo, log, taskId, buildConfig, Optional.of(resolvedConfig));
   }
 
   @Override

--- a/BlazarService/src/main/java/com/hubspot/blazar/resources/BuildResource.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/resources/BuildResource.java
@@ -90,11 +90,17 @@ public class BuildResource {
 
     boolean completed = build.get().getBuild().getState().isComplete();
     Optional<String> logUrl = build.get().getBuild().getLog();
-    if (!logUrl.isPresent()) {
-      throw new NotFoundException("No build log URL found for ID " + id);
+    Optional<String> taskIdOptional = build.get().getBuild().getTaskId();
+    if (!logUrl.isPresent() && !taskIdOptional.isPresent()) {
+      throw new NotFoundException("No build log URL or taskId found for ID " + id);
     }
 
-    String taskId = parseTaskId(logUrl.get());
+    String taskId;
+    if (taskIdOptional.isPresent()) {
+      taskId = taskIdOptional.get();
+    } else {
+      taskId = parseTaskId(logUrl.get());
+    }
     String path = taskId + "/service.log";
     Optional<String> grep = Optional.absent();
 


### PR DESCRIPTION
We might get rid of the log field in the future; but for now we need both.