### PR TITLE
only request build updates after initial request

### DIFF
--- a/BlazarUI/app/scripts/actions/buildsActions.js
+++ b/BlazarUI/app/scripts/actions/buildsActions.js
@@ -8,8 +8,7 @@ const BuildsActions = Reflux.createActions([
   'loadBuildsError'
 ]);
 
-
-let latestFetch = '';
+let latestFetch = 0;
 
 BuildsActions.loadBuilds.preEmit = function() {
 

--- a/BlazarUI/app/scripts/actions/buildsActions.js
+++ b/BlazarUI/app/scripts/actions/buildsActions.js
@@ -8,6 +8,9 @@ const BuildsActions = Reflux.createActions([
   'loadBuildsError'
 ]);
 
+
+let latestFetch = '';
+
 BuildsActions.loadBuilds.preEmit = function() {
 
   (function doPoll() {
@@ -23,11 +26,17 @@ BuildsActions.fetchBuilds = () => {
 };
 
 function fetchBuilds(cb) {
+
   const builds = new Builds();
+  builds.updatedTimestamp = latestFetch;
   const promise = builds.fetch();
 
   promise.done( () => {
     BuildsActions.loadBuildsSuccess(builds.get());
+
+    // store latest timestamp so we can
+    // use in our since parameter when fetching
+    latestFetch = builds.updatedTimestamp;
   });
 
   promise.always( () => {

--- a/BlazarUI/app/scripts/collections/Builds.js
+++ b/BlazarUI/app/scripts/collections/Builds.js
@@ -4,8 +4,17 @@ import BaseCollection from './BaseCollection';
 
 class Builds extends BaseCollection {
 
+  constructor() {
+    this.cache = null;
+    this.updatedTimestamp = '';
+  }
+
+  parse() {
+    super.parse();
+  }
+
   url() {
-    return `${config.apiRoot}/build/states?property=!lastBuild.commitInfo&property=!inProgressBuild.commitInfo&property=!pendingBuild.commitInfo`;
+    return `${config.apiRoot}/build/states?property=!lastBuild.commitInfo&property=!inProgressBuild.commitInfo&property=!pendingBuild.commitInfo&since=${this.updatedTimestamp}`;
   }
 
   hasBuildState() {
@@ -53,7 +62,7 @@ class Builds extends BaseCollection {
   }
 
   getBranchModules(branchInfo) {
-    const modules = findWhere(this.groupBuildsByRepo(), {
+    const modules = findWhere(this.groupByRepo(), {
       organization: branchInfo.org,
       repository: branchInfo.repo,
       branch: branchInfo.branch
@@ -63,7 +72,7 @@ class Builds extends BaseCollection {
   }
 
   getBranchesByRepo(repoInfo) {
-    const groupedBuilds = this.groupBuildsByRepo();
+    const groupedBuilds = this.groupByRepo();
     let branches = groupedBuilds.filter((repo) => {
       return (repo.organization === repoInfo.org) && (repo.repository === repoInfo.repo);
     });
@@ -85,8 +94,7 @@ class Builds extends BaseCollection {
     return branches;
   }
 
-
-  groupBuildsByRepo() {
+  groupByRepo() {
     // group and generate key, by org::repo[branch]
     const grouped = groupBy(this.data, function(o) {
       return `${o.gitInfo.organization}::${o.gitInfo.repository}[${o.gitInfo.branch}]`;

--- a/BlazarUI/app/scripts/collections/Builds.js
+++ b/BlazarUI/app/scripts/collections/Builds.js
@@ -5,7 +5,6 @@ import BaseCollection from './BaseCollection';
 class Builds extends BaseCollection {
 
   constructor() {
-    this.cache = null;
     this.updatedTimestamp = '';
   }
 

--- a/BlazarUI/app/scripts/collections/Builds.js
+++ b/BlazarUI/app/scripts/collections/Builds.js
@@ -5,7 +5,7 @@ import BaseCollection from './BaseCollection';
 class Builds extends BaseCollection {
 
   constructor() {
-    this.updatedTimestamp = '';
+    this.updatedTimestamp = 0;
   }
 
   parse() {

--- a/BlazarUI/app/scripts/collections/Collection.js
+++ b/BlazarUI/app/scripts/collections/Collection.js
@@ -22,6 +22,11 @@ class Collection {
 
     promise.done( (resp) => {
       this.data = resp;
+      const timestampHeader = promise.getResponseHeader('x-last-modified-timestamp');
+      if (timestampHeader) {
+        this.updatedTimestamp = timestampHeader;
+      }
+
       this.parse();
     });
 

--- a/BlazarUI/app/scripts/stores/buildsStore.js
+++ b/BlazarUI/app/scripts/stores/buildsStore.js
@@ -1,19 +1,10 @@
 import Reflux from 'reflux';
 import BuildsActions from '../actions/buildsActions';
-import {pluck} from 'underscore';
-
-
-function getBuildsIds(builds) {
-  return pluck(pluck(builds, 'module'), 'id');
-}
 
 function updateBuilds(latest, builds) {
-
-  const latestIds = getBuildsIds(latest);
-
   for (let i = 0, len = builds.length; i < len; i++) {
-    for (let g = 0, len = latestIds.length; g < len; g++) {
-      if (latestIds[g] === builds[i].module.id) {
+    for (let g = 0, len = latest.length; g < len; g++) {
+      if (latest[g].module.id === builds[i].module.id) {
         builds[i] = latest[g];
         break;
       }
@@ -21,9 +12,7 @@ function updateBuilds(latest, builds) {
   }
 
   return builds;
-
 }
-
 
 const BuildsStore = Reflux.createStore({
 

--- a/BlazarUI/app/scripts/stores/buildsStore.js
+++ b/BlazarUI/app/scripts/stores/buildsStore.js
@@ -1,5 +1,29 @@
 import Reflux from 'reflux';
 import BuildsActions from '../actions/buildsActions';
+import {pluck} from 'underscore';
+
+
+function getBuildsIds(builds) {
+  return pluck(pluck(builds, 'module'), 'id');
+}
+
+function updateBuilds(latest, builds) {
+
+  const latestIds = getBuildsIds(latest);
+
+  for (let i = 0, len = builds.length; i < len; i++) {
+    for (let g = 0, len = latestIds.length; g < len; g++) {
+      if (latestIds[g] === builds[i].module.id) {
+        builds[i] = latest[g];
+        break;
+      }
+    }
+  }
+
+  return builds;
+
+}
+
 
 const BuildsStore = Reflux.createStore({
 
@@ -8,14 +32,11 @@ const BuildsStore = Reflux.createStore({
   init() {
     this.builds = [];
     this.buildsLoaded = false;
+    this.buildsHaveLoaded = false;
   },
 
   getBuilds() {
     return this.builds;
-  },
-
-  haveBuildsLoaded() {
-    return this.buildsLoaded;
   },
 
   loadBuilds() {
@@ -24,14 +45,25 @@ const BuildsStore = Reflux.createStore({
     });
   },
 
-  loadBuildsSuccess(builds) {
-    this.builds = builds;
-    this.buildsHaveLoaded = true;
+  loadBuildsSuccess(incomingBuilds) {
+
+    // first fetch
+    if (!this.buildsHaveLoaded) {
+      this.builds = incomingBuilds;
+    }
+
+    // subsequent fetches
+    else {
+      const updatedBuilds = updateBuilds(incomingBuilds, this.builds);
+      this.builds = updatedBuilds;
+    }
 
     this.trigger({
       builds: this.builds,
       loadingBuilds: false
     });
+
+    this.buildsHaveLoaded = true;
   },
 
   loadBuildsError(error) {

--- a/BlazarUI/app/scripts/stores/buildsStore.js
+++ b/BlazarUI/app/scripts/stores/buildsStore.js
@@ -1,18 +1,6 @@
 import Reflux from 'reflux';
 import BuildsActions from '../actions/buildsActions';
-
-function updateBuilds(latest, builds) {
-  for (let i = 0, len = builds.length; i < len; i++) {
-    for (let g = 0, len = latest.length; g < len; g++) {
-      if (latest[g].module.id === builds[i].module.id) {
-        builds[i] = latest[g];
-        break;
-      }
-    }
-  }
-
-  return builds;
-}
+import {updateBuilds} from '../utils/buildsHelpers';
 
 const BuildsStore = Reflux.createStore({
 
@@ -35,12 +23,10 @@ const BuildsStore = Reflux.createStore({
   },
 
   loadBuildsSuccess(incomingBuilds) {
-
-    // first fetch
+    // initial fetch
     if (!this.buildsHaveLoaded) {
       this.builds = incomingBuilds;
     }
-
     // subsequent fetches
     else {
       const updatedBuilds = updateBuilds(incomingBuilds, this.builds);

--- a/BlazarUI/app/scripts/utils/buildsHelpers.js
+++ b/BlazarUI/app/scripts/utils/buildsHelpers.js
@@ -1,8 +1,9 @@
 import Search from './search';
 import {getStarredModules} from './starHelpers';
 import {filter, has, sortBy} from 'underscore';
+import bs from 'binary-search';
 
-export const getFilterMatches = function(builds, filterText) {
+export const getFilterMatches = (builds, filterText) => {
   if (builds.length === 0) {
     return [];
   }
@@ -25,8 +26,35 @@ export const filterByToggle = (filterState, modules, stars) => {
     modules = sortBy(buildingModules, function(r) {
       return -r.inProgressBuild.startTimestamp;
     });
-
   }
 
   return modules;
+};
+
+function binarySearch(haystack, needle) {
+  return bs(haystack, needle, (a, b) => {
+    return a.module.id - b.module.id;
+  });
+}
+
+export const updateBuilds = (latestBuilds, currentBuilds) => {
+
+  currentBuilds.sort((a, b) => {
+    return a.module.id - b.module.id;
+  });
+
+  for (let i = 0, len = latestBuilds.length; i < len; i++) {
+    const buildIndex = binarySearch(currentBuilds, latestBuilds[i]);
+
+    if (buildIndex > 0) {
+      currentBuilds[buildIndex] = latestBuilds[i];
+    }
+
+    else {
+      currentBuilds.push(latestBuilds[i]);
+    }
+
+  }
+
+  return currentBuilds;
 };

--- a/BlazarUI/package.json
+++ b/BlazarUI/package.json
@@ -18,6 +18,7 @@
     "babel-core": "^4.7.0",
     "babel-jest": "^4.0.0",
     "babel-loader": "^4.2.0",
+    "binary-search": "^1.2.0",
     "bootstrap": "^3.3.5",
     "classnames": "^2.1.3",
     "del": "^1.1.1",


### PR DESCRIPTION
Previously all builds were fetched during each request (a whopping ~2mb every 5 seconds), this update passes a ?since parameter which only receives builds that have updated since the last request (only ~1-4kb), and updates the builds store with any of these updates. 

@tpetr - right now I'm just storing the builds it in memory - after thinking about it I'm not sure there is a great benefit keeping it in local storage (and could potentially be less useful given local storage is synchronous and it would be hit often) since it's only the first request which is large (eg 2mbs), then its typically quite small.

//cc @jhaber 