### PR TITLE
(WIP) Better log

### DIFF
--- a/BlazarUI/app/index.mustache
+++ b/BlazarUI/app/index.mustache
@@ -32,6 +32,7 @@
         staticRoot: "{{{staticRoot}}}",
         {{#buildsRefresh}}buildsRefresh: {{{buildsRefresh}}},{{/buildsRefresh}}
         appRoot: "{{{appRoot}}}",
+        offsetLength: "{{{offsetLength}}}",
         {{#apiRoot}}apiRoot: "{{{apiRoot}}}",{{/apiRoot}}
         {{^apiRoot}}apiRoot: localStorage.getItem("apiRootOverride"),{{/apiRoot}}
       }

--- a/BlazarUI/app/index.mustache
+++ b/BlazarUI/app/index.mustache
@@ -32,7 +32,7 @@
         staticRoot: "{{{staticRoot}}}",
         {{#buildsRefresh}}buildsRefresh: {{{buildsRefresh}}},{{/buildsRefresh}}
         appRoot: "{{{appRoot}}}",
-        offsetLength: "{{{offsetLength}}}",
+        offsetLength: {{{offsetLength}}},
         {{#apiRoot}}apiRoot: "{{{apiRoot}}}",{{/apiRoot}}
         {{^apiRoot}}apiRoot: localStorage.getItem("apiRootOverride"),{{/apiRoot}}
       }

--- a/BlazarUI/app/index.mustache
+++ b/BlazarUI/app/index.mustache
@@ -31,6 +31,8 @@
       window.config = {
         staticRoot: "{{{staticRoot}}}",
         {{#buildsRefresh}}buildsRefresh: {{{buildsRefresh}}},{{/buildsRefresh}}
+        {{#activeBuildRefresh}}activeBuildRefresh: {{{activeBuildRefresh}}},{{/activeBuildRefresh}}
+        
         appRoot: "{{{appRoot}}}",
         offsetLength: {{{offsetLength}}},
         {{#apiRoot}}apiRoot: "{{{apiRoot}}}",{{/apiRoot}}

--- a/BlazarUI/app/scripts/actions/buildActions.js
+++ b/BlazarUI/app/scripts/actions/buildActions.js
@@ -25,7 +25,7 @@ const BuildActions = Reflux.createActions([
   'triggerBuildStart',
   'loadBuildCancelError',
   'loadBuildCancelled',
-  'navigateLogChange',
+  'changeOffsetWithNavigation',
   'pageUp'
 ]);
 
@@ -41,7 +41,7 @@ BuildActions.pageUp = function(moduleId) {
   pageBuild(builds[moduleId]);
 };
 
-BuildActions.navigateLogChange = function(moduleId, position) {
+BuildActions.changeOffsetWithNavigation = function(moduleId, position) {
   const build = builds[moduleId];
   const updatedOffset = position === 'top' ? 0 : build.log.options.lastOffset;
 
@@ -197,6 +197,9 @@ function processBuild() {
 
 
 
+
+
+
 function processInProgressBuild(build) {
   let inProgressBuild = {
     logLines: '',
@@ -249,6 +252,10 @@ function processInProgressBuild(build) {
 
   })();
 }
+
+
+
+
 //
 // Inactive Build Methods
 //
@@ -275,7 +282,13 @@ function fetchInactiveBuildLog(build) {
   });
 };
 
-// share?
+
+
+
+
+//
+// Shared Methods
+//
 function updateStore(build, log, data, textStatus, jqxhr) {
   if (jqxhr.responseJSON === undefined || textStatus !== 'success') {
     BuildActions.loadBuildSuccess({
@@ -292,12 +305,11 @@ function updateStore(build, log, data, textStatus, jqxhr) {
     fetchingLog: false,
     currentOffset: log.options.offset,
     currrentOffsetLine: log.currrentOffsetLine,
-    scrollToOffset: log.scrollToOffset
+    scrollToOffset: log.scrollToOffset,
+    positionChange: build.log.positionChange
   });
 }
-//
-// Shared Methods
-//
+
 function getLogSize(build, cb) {
   const logSize = new LogSize({
     buildNumber: build.data.build.id
@@ -326,12 +338,10 @@ function loadOffset(options) {
     .setOffset(updatedOffset)
     .fetch()
     .always((data, textStatus, jqxhr) => {
-      
       if (position) {
         build.log.scrollToOffset = position === 'top' ? build.log.currrentOffsetLine : build.log.lastOffsetLine;
         build.log.positionChange = position;
       }
-
       updateStore(build, build.log, data, textStatus, jqxhr)
   });
 

--- a/BlazarUI/app/scripts/actions/buildActions.js
+++ b/BlazarUI/app/scripts/actions/buildActions.js
@@ -66,7 +66,7 @@ BuildActions.pageLog = function(moduleId, direction) {
 
 BuildActions.fetchStartOfLog = function(moduleId, options={}) {
   builds[moduleId].shouldPoll = false;
-  
+
   if (options.position) {
     builds[moduleId].log.positionChange = options.position;
   }
@@ -353,16 +353,21 @@ function handleScroll(build, direction, isActive) {
   build.log.direction = direction;
   build.log.positionChange = undefined;
   
+  // Log size is smaller than one offsetLength so nothing more to fetch
+  if (build.log.options.logSize < config.offsetLength) {
+    return;
+  }
+
   if (direction === 'down') {
     // if we are at the end of the log, started at the end and since scrolled up,
     // or our log is less than one offset length
     if (build.log.endOfLogLoaded || build.log.options.logSize < config.offsetLength + 1) {
       return;
     }
-
   }
 
   else if (direction === 'up') {
+    // If we made it to the top, dont fetch anything
     if (build.log.previousOffset < config.offsetLength) {
       return;
     }

--- a/BlazarUI/app/scripts/actions/buildActions.js
+++ b/BlazarUI/app/scripts/actions/buildActions.js
@@ -177,6 +177,15 @@ function getLogSize() {
     requestedBuild.logSize = size;
     build.log = createLogModel(build, requestedBuild.logSize);
   });
+  
+  sizePromise.error((err) => {
+    console.warn(err);
+    BuildActions.loadBuildSuccess({
+      log: [{ text: `Error loading log, we don't have the log size. View your console for more detail.`}],
+      build: build.data
+    });
+    
+  });
 
   return sizePromise;
 }

--- a/BlazarUI/app/scripts/actions/buildActions.js
+++ b/BlazarUI/app/scripts/actions/buildActions.js
@@ -368,7 +368,7 @@ function handleScroll(build, direction, isActive) {
 
   else if (direction === 'up') {
     // If we made it to the top, dont fetch anything
-    if (build.log.previousOffset < config.offsetLength) {
+    if (build.log.startOfLogLoaded) {
       return;
     }
   }
@@ -388,6 +388,7 @@ function resetBuild(options) {
   } = options;
 
   build.log.endOfLogLoaded = false;
+  build.log.startOfLogLoaded = false;
 
   build.log
     .reset()

--- a/BlazarUI/app/scripts/actions/buildActions.js
+++ b/BlazarUI/app/scripts/actions/buildActions.js
@@ -350,9 +350,9 @@ function createLogModel(build, size) {
 // fetch previous/next offsets when scrolling up/down log
 function handleScroll(build, direction, isActive) {
   build.log.hasNavigatedWithButtons = false;
+  build.log.positionChange = false
   build.log.direction = direction;
-  build.log.positionChange = undefined;
-  
+
   // Log size is smaller than one offsetLength so nothing more to fetch
   if (build.log.options.logSize < config.offsetLength) {
     return;

--- a/BlazarUI/app/scripts/components/Helpers.js
+++ b/BlazarUI/app/scripts/components/Helpers.js
@@ -150,7 +150,7 @@ export const getFilteredModules = function(filters, modules) {
 }
 
 export const buildIsOnDeck = function(buildState) {
-  return contains([BuildStates.LAUNCHING, buildState.QUEUED], buildState);
+  return contains([BuildStates.LAUNCHING, BuildStates.QUEUED], buildState);
 }
 
 export const buildIsInactive = function(buildState) {

--- a/BlazarUI/app/scripts/components/Helpers.js
+++ b/BlazarUI/app/scripts/components/Helpers.js
@@ -1,6 +1,6 @@
 // Using in favor of Deprecated ComponentHelpers.js
 import React from 'react';
-import {some, uniq, flatten, filter} from 'underscore';
+import {some, uniq, flatten, filter, contains} from 'underscore';
 import moment from 'moment';
 import BuildStates from '../constants/BuildStates.js';
 import {LABELS, iconStatus} from './constants';
@@ -147,6 +147,14 @@ export const getFilteredModules = function(filters, modules) {
   return filteredModules.sort( (a, b) => {
     return cmp(a.gitInfo.branch, b.gitInfo.branch) || cmp(a.module.name, b.module.name);
   });  
+}
+
+export const buildIsOnDeck = function(buildState) {
+  return contains([BuildStates.LAUNCHING, buildState.QUEUED], buildState);
+}
+
+export const buildIsInactive = function(buildState) {
+  contains([BuildStates.SUCCESS, BuildStates.FAILED, BuildStates.CANCELLED], buildState)
 }
 
 // DOM Helpers

--- a/BlazarUI/app/scripts/components/build/Build.jsx
+++ b/BlazarUI/app/scripts/components/build/Build.jsx
@@ -44,6 +44,7 @@ class Build extends Component {
               <BuildLogNavigation 
                 changeOffsetWithNavigation={this.props.changeOffsetWithNavigation}
                 buildState={build.state}
+                loading={this.props.loading}
               />
             </UIGridItem>
           </UIGrid>

--- a/BlazarUI/app/scripts/components/build/Build.jsx
+++ b/BlazarUI/app/scripts/components/build/Build.jsx
@@ -9,7 +9,7 @@ import BuildDetail from './BuildDetail.jsx';
 
 import BuildLogNavigation from './BuildLogNavigation.jsx';
 import BuildLog from './BuildLog.jsx';
-import AjaxErrorAlert from '../shared/AjaxErrorAlert.jsx';
+import GenericErrorMessage from '../shared/GenericErrorMessage.jsx';
 
 class Build extends Component {
 
@@ -31,9 +31,6 @@ class Build extends Component {
         <div className='build-header'>
           <UIGrid>
             <UIGridItem size={8}>
-              <AjaxErrorAlert 
-                error={this.props.error}
-              />
               <BuildHeadline 
                 moduleName={this.props.params.module}
                 moduleId={this.props.params.moduleId}
@@ -52,6 +49,9 @@ class Build extends Component {
           </UIGrid>
           <UIGrid>
             <UIGridItem size={12}>
+              <GenericErrorMessage 
+                message={this.props.error}
+              />
               <BuildDetail
                 build={this.props.build}
                 loading={this.props.loading}
@@ -63,15 +63,14 @@ class Build extends Component {
         <div className='build-body'>
           <div>  
             <BuildLog
-              log={this.props.log}
-              positionChange={this.props.positionChange}
               fetchingLog={this.props.fetchingLog}
+              shouldPoll={this.props.shouldPoll}
+              fetchStartOfLog={this.props.fetchStartOfLog}
+              fetchEndOfLog={this.props.fetchEndOfLog}
               pageLog={this.props.pageLog}
               buildState={build.state}
               loading={this.props.loading}
-              currentOffset={this.props.currentOffset}
-              currrentOffsetLine={this.props.currrentOffsetLine}
-              lastOffsetLine={this.props.lastOffsetLine}
+              log={this.props.log}
             />
           </div>
         </div>
@@ -88,17 +87,18 @@ Build.propTypes = {
     module: PropTypes.object
   }),
   error: PropTypes.node,
-  positionChange: PropTypes.node,
+  fetchStartOfLog: PropTypes.func.isRequired,
+  fetchEndOfLog: PropTypes.func.isRequired,
+  shouldPoll: PropTypes.func.isRequired,
   changeOffsetWithNavigation: PropTypes.func.isRequired,
-  log: PropTypes.array,
+  log: PropTypes.object,
   fetchingLog: PropTypes.bool,
-  currentOffset: PropTypes.number,
   params: PropTypes.object,
   loading: PropTypes.bool,
+  triggerCancelBuild: PropTypes.func.isRequired,
   toggleStar: PropTypes.func.isRequired,
   isStarred: PropTypes.bool.isRequired,
-  pathname: PropTypes.string.isRequired,
-  triggerCancelBuild: PropTypes.func.isRequired
+  pathname: PropTypes.string.isRequired
 };
 
 export default Build;

--- a/BlazarUI/app/scripts/components/build/Build.jsx
+++ b/BlazarUI/app/scripts/components/build/Build.jsx
@@ -10,7 +10,7 @@ import BuildCommits from './BuildCommits.jsx';
 import BuildLogNavigation from './BuildLogNavigation.jsx';
 import BuildLog from './BuildLog.jsx';
 import CancelBuildButton from './CancelBuildButton.jsx';
-import ErrorAlert from '../shared/ErrorAlert.jsx';
+import AjaxErrorAlert from '../shared/AjaxErrorAlert.jsx';
 
 class Build extends Component {
 
@@ -32,7 +32,7 @@ class Build extends Component {
         <div className='build-header'>
           <UIGrid>
             <UIGridItem size={8}>
-              <ErrorAlert 
+              <AjaxErrorAlert 
                 error={this.props.error}
               />
               <BuildHeadline 
@@ -51,6 +51,7 @@ class Build extends Component {
               />
               <BuildLogNavigation 
                 changeOffsetWithNavigation={this.props.changeOffsetWithNavigation}
+                buildState={build.state}
               />
             </UIGridItem>
           </UIGrid>

--- a/BlazarUI/app/scripts/components/build/Build.jsx
+++ b/BlazarUI/app/scripts/components/build/Build.jsx
@@ -69,12 +69,12 @@ class Build extends Component {
               log={this.props.log}
               positionChange={this.props.positionChange}
               fetchingLog={this.props.fetchingLog}
-              pageUp={this.props.pageUp}
-              scrollToOffset={this.props.scrollToOffset}
+              pageLog={this.props.pageLog}
               buildState={build.state}
               loading={this.props.loading}
               currentOffset={this.props.currentOffset}
               currrentOffsetLine={this.props.currrentOffsetLine}
+              lastOffsetLine={this.props.lastOffsetLine}
             />
           </div>
         </div>
@@ -91,10 +91,9 @@ Build.propTypes = {
     module: PropTypes.object
   }),
   error: PropTypes.node,
-  positionChange: PropTypes.string,
+  positionChange: PropTypes.node,
   changeOffsetWithNavigation: PropTypes.func.isRequired,
   log: PropTypes.array,
-  scrollToOffset: PropTypes.number,
   fetchingLog: PropTypes.bool,
   currentOffset: PropTypes.number,
   params: PropTypes.object,

--- a/BlazarUI/app/scripts/components/build/Build.jsx
+++ b/BlazarUI/app/scripts/components/build/Build.jsx
@@ -9,7 +9,6 @@ import BuildDetail from './BuildDetail.jsx';
 import BuildCommits from './BuildCommits.jsx';
 import BuildLogNavigation from './BuildLogNavigation.jsx';
 import BuildLog from './BuildLog.jsx';
-import CancelBuildButton from './CancelBuildButton.jsx';
 import AjaxErrorAlert from '../shared/AjaxErrorAlert.jsx';
 
 class Build extends Component {
@@ -45,10 +44,6 @@ class Build extends Component {
               />
             </UIGridItem>
             <UIGridItem size={4}>
-              <CancelBuildButton 
-                triggerCancelBuild={this.props.triggerCancelBuild}
-                build={this.props.build}
-              />
               <BuildLogNavigation 
                 changeOffsetWithNavigation={this.props.changeOffsetWithNavigation}
                 buildState={build.state}
@@ -60,6 +55,7 @@ class Build extends Component {
               <BuildDetail
                 build={this.props.build}
                 loading={this.props.loading}
+                triggerCancelBuild={this.props.triggerCancelBuild}
               />
             </UIGridItem>
           </UIGrid>  

--- a/BlazarUI/app/scripts/components/build/Build.jsx
+++ b/BlazarUI/app/scripts/components/build/Build.jsx
@@ -7,6 +7,7 @@ import Loader from '../shared/Loader.jsx';
 import BuildHeadline from './BuildHeadline.jsx';
 import BuildDetail from './BuildDetail.jsx';
 import BuildCommits from './BuildCommits.jsx';
+import BuildLogNavigation from './BuildLogNavigation.jsx';
 import BuildLog from './BuildLog.jsx';
 import CancelBuildButton from './CancelBuildButton.jsx';
 import ErrorAlert from '../shared/ErrorAlert.jsx';
@@ -14,7 +15,6 @@ import ErrorAlert from '../shared/ErrorAlert.jsx';
 class Build extends Component {
 
   render() {
-
     if (this.props.loading) {
       return (
         <Loader align='top-center' />
@@ -29,49 +29,55 @@ class Build extends Component {
 
     return (
       <div>
-        <UIGrid>
-          <UIGridItem size={10}>
-            <ErrorAlert 
-              error={this.props.error}
-            />
-            <BuildHeadline 
-              moduleName={this.props.params.module}
-              moduleId={this.props.params.moduleId}
-              modulePath={this.props.pathname}
-              buildNumber={parseInt(this.props.params.buildNumber)}
-              isStarred={this.props.isStarred}
-              toggleStar={this.props.toggleStar}
-            />
-          </UIGridItem>
-          <UIGridItem size={2}>
-            <CancelBuildButton 
-              triggerCancelBuild={this.props.triggerCancelBuild}
-              build={this.props.build}
-            />
-          </UIGridItem>
-        </UIGrid>
-        <UIGrid>
-          <UIGridItem size={12}>
-            <BuildDetail
-              build={this.props.build}
-              loading={this.props.loading}
-            />
-          </UIGridItem>
-        </UIGrid>  
-        <UIGrid>  
-          <UIGridItem size={12}>
-            <BuildCommits 
-              build={this.props.build}
-              loading={this.props.loading}
-            />
+        <div className='build-header'>
+          <UIGrid>
+            <UIGridItem size={8}>
+              <ErrorAlert 
+                error={this.props.error}
+              />
+              <BuildHeadline 
+                moduleName={this.props.params.module}
+                moduleId={this.props.params.moduleId}
+                modulePath={this.props.pathname}
+                buildNumber={parseInt(this.props.params.buildNumber)}
+                isStarred={this.props.isStarred}
+                toggleStar={this.props.toggleStar}
+              />
+            </UIGridItem>
+            <UIGridItem size={4}>
+              <CancelBuildButton 
+                triggerCancelBuild={this.props.triggerCancelBuild}
+                build={this.props.build}
+              />
+              <BuildLogNavigation 
+                navigateLogChange={this.props.navigateLogChange}
+              />
+            </UIGridItem>
+          </UIGrid>
+          <UIGrid>
+            <UIGridItem size={12}>
+              <BuildDetail
+                build={this.props.build}
+                loading={this.props.loading}
+              />
+            </UIGridItem>
+          </UIGrid>  
+        </div>
+        <div className='build-body'>
+          <div>  
             <BuildLog
               log={this.props.log}
+              navigating={this.props.navigating}
               fetchingLog={this.props.fetchingLog}
+              pageUp={this.props.pageUp}
+              scrollToOffset={this.props.scrollToOffset}
               buildState={build.state}
               loading={this.props.loading}
+              currentOffset={this.props.currentOffset}
+              currrentOffsetLine={this.props.currrentOffsetLine}
             />
-          </UIGridItem>
-        </UIGrid>
+          </div>
+        </div>
       </div>
     );
   }
@@ -85,9 +91,12 @@ Build.propTypes = {
     module: PropTypes.object
   }),
   error: PropTypes.node,
-  log: PropTypes.string,
+  navigating: PropTypes.string,
+  navigateLogChange: PropTypes.func.isRequired,
+  log: PropTypes.array,
+  scrollToOffset: PropTypes.number,
   fetchingLog: PropTypes.bool,
-  originalParams: PropTypes.object,
+  currentOffset: PropTypes.number,
   params: PropTypes.object,
   loading: PropTypes.bool,
   toggleStar: PropTypes.func.isRequired,

--- a/BlazarUI/app/scripts/components/build/Build.jsx
+++ b/BlazarUI/app/scripts/components/build/Build.jsx
@@ -50,7 +50,7 @@ class Build extends Component {
                 build={this.props.build}
               />
               <BuildLogNavigation 
-                navigateLogChange={this.props.navigateLogChange}
+                changeOffsetWithNavigation={this.props.changeOffsetWithNavigation}
               />
             </UIGridItem>
           </UIGrid>
@@ -67,7 +67,7 @@ class Build extends Component {
           <div>  
             <BuildLog
               log={this.props.log}
-              navigating={this.props.navigating}
+              positionChange={this.props.positionChange}
               fetchingLog={this.props.fetchingLog}
               pageUp={this.props.pageUp}
               scrollToOffset={this.props.scrollToOffset}
@@ -91,8 +91,8 @@ Build.propTypes = {
     module: PropTypes.object
   }),
   error: PropTypes.node,
-  navigating: PropTypes.string,
-  navigateLogChange: PropTypes.func.isRequired,
+  positionChange: PropTypes.string,
+  changeOffsetWithNavigation: PropTypes.func.isRequired,
   log: PropTypes.array,
   scrollToOffset: PropTypes.number,
   fetchingLog: PropTypes.bool,

--- a/BlazarUI/app/scripts/components/build/Build.jsx
+++ b/BlazarUI/app/scripts/components/build/Build.jsx
@@ -6,7 +6,7 @@ import Loader from '../shared/Loader.jsx';
 
 import BuildHeadline from './BuildHeadline.jsx';
 import BuildDetail from './BuildDetail.jsx';
-import BuildCommits from './BuildCommits.jsx';
+
 import BuildLogNavigation from './BuildLogNavigation.jsx';
 import BuildLog from './BuildLog.jsx';
 import AjaxErrorAlert from '../shared/AjaxErrorAlert.jsx';

--- a/BlazarUI/app/scripts/components/build/BuildCommits.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildCommits.jsx
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import CommitsTable from './CommitsTable.jsx';
 import Loader from '../shared/Loader.jsx';
-import Collapsable from '../shared/Collapsable.jsx';
+
 import {has} from 'underscore';
 import {timestampFormatted} from '../Helpers';
 import MutedMessage from '../shared/MutedMessage.jsx';
@@ -9,50 +9,25 @@ import MutedMessage from '../shared/MutedMessage.jsx';
 class BuildCommits extends Component {
 
   render() {
-
-    if (!has(this.props.build.build,'commitInfo')) {
-      return <div />;
+    
+    if (!this.props.showCommits) {
+      return null;
     }
 
-    const commitInfo = this.props.build.build.commitInfo;
+    if (!has(this.props.build.build,'commitInfo')) {
+      return (
+        <div>No commit info</div>
+      )
+    }
 
     if (this.props.loading) {
       return <Loader />;
     }
 
-    const inflection = commitInfo.newCommits.length !== 1 ? 's' : '';
-
-
-    let header;
-
-    if (commitInfo.newCommits.length === 0) {
-      header = (
-        <span>No new commits since previous build</span>
-      );
-    }
-
-    else {
-      header = (
-        <span>
-          <span className='badge roomy-x'>
-            {commitInfo.newCommits.length}
-          </span> 
-          new commit{inflection} since previous build 
-        </span>
-      );
-    }
-
     return (
-      <Collapsable
-        header={header}
-        initialToggleStateOpen={false}
-        disableToggle={commitInfo.newCommits.length === 0}
-      >
-        <CommitsTable 
-          commits={this.props.build.build.commitInfo.newCommits}
-        />
-
-      </Collapsable>
+      <CommitsTable 
+        commits={this.props.build.build.commitInfo.newCommits}
+      />
     );
   }
 
@@ -60,6 +35,7 @@ class BuildCommits extends Component {
 
 BuildCommits.propTypes = {
   build: PropTypes.object,
+  showCommits: PropTypes.bool.isRequired,
   loading: PropTypes.bool
 };
 

--- a/BlazarUI/app/scripts/components/build/BuildContainer.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildContainer.jsx
@@ -63,7 +63,7 @@ class BuildContainer extends Component {
   componentWillUnmount() {
     this.tearDown()
   }
-  
+
   pageLog(direction) {
     BuildActions.pageLog(this.props.params.moduleId, direction);
   }
@@ -77,24 +77,15 @@ class BuildContainer extends Component {
   }
 
   onStatusChange(state) {
-    let stateUpdate = {}
+    // let stateUpdate = {}
     
-    if (state.loadBuildCancelError) {
-      this.setState({
-        error: state.loadBuildCancelError
-      });
-      
-      // TO DO
-      // stateUpdate.error = state.loadBuildCancelError
-    }
+    // To do: handle cancelled build error
 
     if (state.loading) {
       this.setState({
         loading: true
       });
-      
-      // stateUpdate.loading = true;
-      // this.setState(stateUpdate)
+
       return;
     }
 

--- a/BlazarUI/app/scripts/components/build/BuildContainer.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildContainer.jsx
@@ -20,7 +20,7 @@ const initialState = {
     module: { name: ''}
   },
   log: [],
-  navigating: null,
+  positionChange: null,
   fetchingLog: false,
   currentOffset: 0,
   currrentOffsetLine: 0,
@@ -32,7 +32,7 @@ class BuildContainer extends Component {
 
   constructor(props) {
     super(props);
-    bindAll(this, 'toggleStar', 'triggerCancelBuild', 'pageUp', 'navigateLogChange');
+    bindAll(this, 'toggleStar', 'triggerCancelBuild', 'pageUp', 'changeOffsetWithNavigation');
     this.state = initialState;
   }
 
@@ -73,11 +73,11 @@ class BuildContainer extends Component {
     BuildActions.pageUp(this.props.params.moduleId);
   }
   
-  navigateLogChange(position) {
+  changeOffsetWithNavigation(position) {
     console.log('navigation change: ', position);
-    BuildActions.navigateLogChange(this.props.params.moduleId, position)
+    BuildActions.changeOffsetWithNavigation(this.props.params.moduleId, position)
     // this.setState({
-    //   navigating: position
+    //   positionChange: position
     // })
   }
   
@@ -115,12 +115,13 @@ class BuildContainer extends Component {
     }
 
     if (state.build) {
+      console.log('state change: ', state.build);
       this.setState({
         loading: false,
         build: state.build.build,
         log: state.build.log,
         fetchingLog: state.build.fetchingLog,
-        
+        positionChange: state.build.positionChange,
         scrollToOffset: state.build.scrollToOffset,
         currentOffset: state.build.currentOffset,
         currrentOffsetLine: state.build.currrentOffsetLine
@@ -145,8 +146,8 @@ class BuildContainer extends Component {
           error={this.state.error}
           build={this.state.build}
           log={this.state.log}
-          navigating={this.state.navigating}
-          navigateLogChange={this.navigateLogChange}
+          positionChange={this.state.positionChange}
+          changeOffsetWithNavigation={this.changeOffsetWithNavigation}
           currentOffset={this.state.currentOffset}
           currrentOffsetLine={this.state.currrentOffsetLine}
           scrollToOffset={this.state.scrollToOffset}

--- a/BlazarUI/app/scripts/components/build/BuildContainer.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildContainer.jsx
@@ -19,8 +19,11 @@ const initialState = {
     gitInfo: {},
     module: { name: ''}
   },
-  log: '',
-  fetchingLog: true,
+  log: [],
+  navigating: null,
+  fetchingLog: false,
+  currentOffset: 0,
+  currrentOffsetLine: 0,
   stars: [],
   error: false
 };
@@ -29,7 +32,7 @@ class BuildContainer extends Component {
 
   constructor(props) {
     super(props);
-    bindAll(this, 'toggleStar', 'triggerCancelBuild');
+    bindAll(this, 'toggleStar', 'triggerCancelBuild', 'pageUp', 'navigateLogChange');
     this.state = initialState;
   }
 
@@ -61,21 +64,47 @@ class BuildContainer extends Component {
     this.tearDown()
   }
   
+  pageUp() {
+    //
+    //
+    // To Do:
+    // Do we need build id???
+    // BuildActions.pageUp(this.state.build.build.id, this.props.params.moduleId);
+    BuildActions.pageUp(this.props.params.moduleId);
+  }
+  
+  navigateLogChange(position) {
+    console.log('navigation change: ', position);
+    BuildActions.navigateLogChange(this.props.params.moduleId, position)
+    // this.setState({
+    //   navigating: position
+    // })
+  }
+  
   triggerCancelBuild(buildId, moduleId) {
     BuildActions.cancelBuild(buildId, moduleId);
   }
 
   onStatusChange(state) {
+    
+    let stateUpdate = {}
+    
     if (state.loadBuildCancelError) {
       this.setState({
         error: state.loadBuildCancelError
-      })
+      });
+      
+      // TO DO
+      // stateUpdate.error = state.loadBuildCancelError
     }
 
     if (state.loading) {
       this.setState({
         loading: true
       });
+      
+      // stateUpdate.loading = true;
+      // this.setState(stateUpdate)
       return;
     }
 
@@ -90,7 +119,11 @@ class BuildContainer extends Component {
         loading: false,
         build: state.build.build,
         log: state.build.log,
-        fetchingLog: state.build.fetchingLog
+        fetchingLog: state.build.fetchingLog,
+        
+        scrollToOffset: state.build.scrollToOffset,
+        currentOffset: state.build.currentOffset,
+        currrentOffsetLine: state.build.currrentOffsetLine
       });
 
       if (contains([BuildStates.QUEUED, BuildStates.LAUNCHING], state.build.build.build.state)){
@@ -112,7 +145,13 @@ class BuildContainer extends Component {
           error={this.state.error}
           build={this.state.build}
           log={this.state.log}
+          navigating={this.state.navigating}
+          navigateLogChange={this.navigateLogChange}
+          currentOffset={this.state.currentOffset}
+          currrentOffsetLine={this.state.currrentOffsetLine}
+          scrollToOffset={this.state.scrollToOffset}
           fetchingLog={this.state.fetchingLog}
+          pageUp={this.pageUp}
           originalParams={this.originalParams}
           params={this.props.params}
           loading={this.state.loading}

--- a/BlazarUI/app/scripts/components/build/BuildContainer.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildContainer.jsx
@@ -32,7 +32,7 @@ class BuildContainer extends Component {
 
   constructor(props) {
     super(props);
-    bindAll(this, 'toggleStar', 'triggerCancelBuild', 'pageUp', 'changeOffsetWithNavigation');
+    bindAll(this, 'toggleStar', 'triggerCancelBuild', 'pageLog', 'changeOffsetWithNavigation');
     this.state = initialState;
   }
 
@@ -64,21 +64,12 @@ class BuildContainer extends Component {
     this.tearDown()
   }
   
-  pageUp() {
-    //
-    //
-    // To Do:
-    // Do we need build id???
-    // BuildActions.pageUp(this.state.build.build.id, this.props.params.moduleId);
-    BuildActions.pageUp(this.props.params.moduleId);
+  pageLog(direction) {
+    BuildActions.pageLog(this.props.params.moduleId, direction);
   }
   
   changeOffsetWithNavigation(position) {
-    console.log('navigation change: ', position);
     BuildActions.changeOffsetWithNavigation(this.props.params.moduleId, position)
-    // this.setState({
-    //   positionChange: position
-    // })
   }
   
   triggerCancelBuild(buildId, moduleId) {
@@ -86,7 +77,6 @@ class BuildContainer extends Component {
   }
 
   onStatusChange(state) {
-    
     let stateUpdate = {}
     
     if (state.loadBuildCancelError) {
@@ -115,16 +105,15 @@ class BuildContainer extends Component {
     }
 
     if (state.build) {
-      console.log('state change: ', state.build);
       this.setState({
         loading: false,
         build: state.build.build,
         log: state.build.log,
         fetchingLog: state.build.fetchingLog,
         positionChange: state.build.positionChange,
-        scrollToOffset: state.build.scrollToOffset,
         currentOffset: state.build.currentOffset,
-        currrentOffsetLine: state.build.currrentOffsetLine
+        currrentOffsetLine: state.build.currrentOffsetLine,
+        lastOffsetLine: state.build.lastOffsetLine
       });
 
       if (contains([BuildStates.QUEUED, BuildStates.LAUNCHING], state.build.build.build.state)){
@@ -150,9 +139,10 @@ class BuildContainer extends Component {
           changeOffsetWithNavigation={this.changeOffsetWithNavigation}
           currentOffset={this.state.currentOffset}
           currrentOffsetLine={this.state.currrentOffsetLine}
-          scrollToOffset={this.state.scrollToOffset}
+          lastOffsetLine={this.state.lastOffsetLine}
+          finalOffset={this.state.finalOffset}
           fetchingLog={this.state.fetchingLog}
-          pageUp={this.pageUp}
+          pageLog={this.pageLog}
           originalParams={this.originalParams}
           params={this.props.params}
           loading={this.state.loading}

--- a/BlazarUI/app/scripts/components/build/BuildContainer.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildContainer.jsx
@@ -87,9 +87,7 @@ class BuildContainer extends Component {
     BuildActions.fetchStartOfLog(this.props.params.moduleId);
   }
   
-  fetchEndOfLog(options) {
-    console.log('fetch from other ', options);
-    
+  fetchEndOfLog(options) {    
     BuildActions.fetchEndOfLog(this.props.params.moduleId, options);
   }
 

--- a/BlazarUI/app/scripts/components/build/BuildContainer.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildContainer.jsx
@@ -95,7 +95,7 @@ class BuildContainer extends Component {
 
   changeOffsetWithNavigation(position) {    
     if (position === 'top') {
-      BuildActions.fetchStartOfLog(this.props.params.moduleId, position)
+      BuildActions.fetchStartOfLog(this.props.params.moduleId, {position: position})
     }
     
     else if (position === 'bottom') {

--- a/BlazarUI/app/scripts/components/build/BuildDetail.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildDetail.jsx
@@ -17,7 +17,7 @@ import {LABELS} from '../constants';
 class BuildDetail extends Component {
 
   constructor() {
-    bindAll(this, 'handleCommitsToggle', 'handleResize')
+    bindAll(this, 'handleResize')
     this.state = {
       windowWidth: window.innerWidth,
       showCommits: false
@@ -38,24 +38,9 @@ class BuildDetail extends Component {
     ]);
   }
   
-  getCommitsIcon() {
-    if (this.state.showCommits) {
-      return <Icon name='times' />
-    }
-    else {
-      return <Icon type='octicon' name='git-commit' />
-    }
-  }
-  
   handleResize(e) {
     this.setState({
       windowWidth: window.innerWidth
-    });
-  }
-  
-  handleCommitsToggle() {
-    this.setState({
-      showCommits: !this.state.showCommits
     });
   }
 
@@ -123,15 +108,7 @@ class BuildDetail extends Component {
         </div>  
         
         <div className='build-detail-body'>
-          <div className='build-detail-body__commits-trigger' title='View commits since previous build' onClick={this.handleCommitsToggle}>
-            {this.getCommitsIcon()}
-          </div>
           <pre className='build-detail-body__commit-desc' title={currentCommit.message}>{truncate(currentCommit.message, this.state.windowWidth * .08, true)}</pre>
-          <BuildCommits
-            build={this.props.build}
-            loading={this.props.loading}
-            showCommits={this.state.showCommits}
-          />
         </div>
         
         <div className='build-detail-footer'> 

--- a/BlazarUI/app/scripts/components/build/BuildDetail.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildDetail.jsx
@@ -3,6 +3,7 @@ import {has, contains} from 'underscore';
 import {humanizeText, timestampFormatted, truncate} from '../Helpers';
 import classNames from 'classnames';
 
+import CancelBuildButton from './CancelBuildButton.jsx';
 import Sha from '../shared/Sha.jsx';
 import Alert from 'react-bootstrap/lib/Alert';
 import Icon from '../shared/Icon.jsx';
@@ -97,6 +98,10 @@ class BuildDetail extends Component {
             Build {buildDetail.buildResult} 
             <span className='build-detail-header__timestamp'>{buildDetail.duration}</span>
           </p>
+          <CancelBuildButton 
+            triggerCancelBuild={this.props.triggerCancelBuild}
+            build={this.props.build}
+          />
         </div>  
         
         <div className='build-detail-body'>

--- a/BlazarUI/app/scripts/components/build/BuildDetail.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildDetail.jsx
@@ -1,7 +1,8 @@
 import React, {Component, PropTypes} from 'react';
-import {has, contains} from 'underscore';
+import {has, contains, bindAll} from 'underscore';
 import {humanizeText, timestampFormatted, truncate} from '../Helpers';
 import classNames from 'classnames';
+import BuildCommits from './BuildCommits.jsx';
 
 import CancelBuildButton from './CancelBuildButton.jsx';
 import Sha from '../shared/Sha.jsx';
@@ -16,16 +17,11 @@ import {LABELS} from '../constants';
 class BuildDetail extends Component {
 
   constructor() {
-    this.handleResize = this.handleResize.bind(this);
+    bindAll(this, 'handleCommitsToggle', 'handleResize')
     this.state = {
-      windowWidth: window.innerWidth
+      windowWidth: window.innerWidth,
+      showCommits: false
     }
-  }
-
-  handleResize(e) {
-    this.setState({
-      windowWidth: window.innerWidth
-    });
   }
 
   componentDidMount() {
@@ -40,6 +36,27 @@ class BuildDetail extends Component {
     return classNames([
       `build-detail alert alert-${LABELS[this.props.build.build.state]}`
     ]);
+  }
+  
+  getCommitsIcon() {
+    if (this.state.showCommits) {
+      return <Icon name='times' />
+    }
+    else {
+      return <Icon type='octicon' name='git-commit' />
+    }
+  }
+  
+  handleResize(e) {
+    this.setState({
+      windowWidth: window.innerWidth
+    });
+  }
+  
+  handleCommitsToggle() {
+    this.setState({
+      showCommits: !this.state.showCommits
+    });
   }
 
   render() {
@@ -89,6 +106,7 @@ class BuildDetail extends Component {
 
     const shaLink = `https://${gitInfo.host}/${gitInfo.organization}/${gitInfo.repository}/commit/${build.sha}`;
 
+    
     return (
       <div className={this.getWrapperClassNames()}>
         
@@ -105,7 +123,15 @@ class BuildDetail extends Component {
         </div>  
         
         <div className='build-detail-body'>
-          <pre title={currentCommit.message} className='build-detail-body__commit-desc'>{truncate(currentCommit.message, this.state.windowWidth * .08, true)}</pre>
+          <div className='build-detail-body__commits-trigger' title='View commits since previous build' onClick={this.handleCommitsToggle}>
+            {this.getCommitsIcon()}
+          </div>
+          <pre className='build-detail-body__commit-desc' title={currentCommit.message}>{truncate(currentCommit.message, this.state.windowWidth * .08, true)}</pre>
+          <BuildCommits
+            build={this.props.build}
+            loading={this.props.loading}
+            showCommits={this.state.showCommits}
+          />
         </div>
         
         <div className='build-detail-footer'> 

--- a/BlazarUI/app/scripts/components/build/BuildLog.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildLog.jsx
@@ -8,6 +8,12 @@ import Loader from '../shared/Loader.jsx';
 import MutedMessage from '../shared/MutedMessage.jsx'
 import BuildStates from '../../constants/BuildStates';
 
+window.$ = $
+
+
+
+
+
 
 class BuildLog extends Component {
 
@@ -23,11 +29,8 @@ class BuildLog extends Component {
     }
   }
   
-  
   componentDidMount() {
     this.scrollId = `offset-${this.props.currrentOffsetLine}`;
-    
-    console.log('did Mount, set scrollId: ', this.props.currrentOffsetLine);
     this.scrollToBottom();
     $('#log').on('scroll', this.handleScroll)
   }
@@ -39,35 +42,39 @@ class BuildLog extends Component {
   }
 
   componentDidUpdate(nextProps, nextState) {
-    console.log('Component Did Update');
-    
-    // store next scroll to value so we can set it
-    // set it after our requestAnimationFrame is complete
-    
-    // If navigating using the 'To Top' and 'To Bottom' buttons
-    if (this.props.navigating) {
-      this.nextScrollId = `offset-${this.props.scrollToOffset}`;
+    // If positionChange using the 'To Top' and 'To Bottom' buttons
+    if (this.props.positionChange) {
+      this.scrollId = `offset-${this.props.scrollToOffset}`;
     }
-    
+    // store next scroll to value so we can set it
+    // set it after our requestAnimationFrame is complete  
     else {
-      console.log('setting scrollId to: ', this.props.currrentOffsetLine);
       this.nextScrollId = `offset-${this.props.currrentOffsetLine}`;
     }
-
-    this.scrollToOffset();
-    // window.requestAnimationFrame(() => {
-    //   this.scrollToOffset();
-    // });
+    // positionChange using 'To Top' and 'To Bottom' buttons
+    // Move to separate method?
+    if (this.props.positionChange) {
+      this.scrollForNavigatonChange();
+    }
+    else {
+      this.scrollToOffset();
+    }
     
-
-
-    // Active builds... --> check position
+    // To Do:
+    // Handle active builds
     // if (nextProps.buildState === BuildStates.IN_PROGRESS) {
   }
   
   componentWillUnmount() {
     $('#log').off('scroll', this.handleScroll)
   }
+  
+
+  // checkPosition() {
+  //   if (this.state.isTailing) {
+  //     this.scrollToBottom();
+  //   }
+  // }
   
   handlePageUp() {
     if (!this.state.hasPaged) {
@@ -76,7 +83,6 @@ class BuildLog extends Component {
   }
 
   handleScroll() {  
-
     const logPosition = $('#log').scrollTop();
     const logHeight = $('#log')[0].scrollHeight - 240
     
@@ -87,10 +93,8 @@ class BuildLog extends Component {
         });
       }
     } 
-    
     // at top of page
     else if ( logPosition <= 30 && !this.state.isPaging) {
-      console.log('handle Page up');
       this.handlePageUp();
         this.setState({
           isPaging: true
@@ -105,73 +109,26 @@ class BuildLog extends Component {
       }
     }
     
-    
-    // // at bottom of page
-    // if ($(window).scrollTop() === $(document).height() - $(window).height()  ) {
-    //   if (this.props.buildState === BuildStates.IN_PROGRESS) {
-    //     this.setState({
-    //       isTailing: true
-    //     });
-    //   }
-    // } 
-    // 
-    // // at top of page
-    // else if ($(window).scrollTop() <= 30 && !this.state.isPaging) {
-    //   this.handlePageUp();
-    //   // show loader at top of build log
-    //   this.setState({
-    //     isPaging: true
-    //   });
-    // }
-    // 
-    // else {
-    //   if (this.props.buildState === BuildStates.IN_PROGRESS) {
-    //     this.setState({
-    //       isTailing: false,
-    //       isPaging: false
-    //     });
-    //   }
-    // }
-    
-    
   }
-  
-  
-  
-  
   
   scrollToOffset() {
     if (!this.scrollId) {
       return;
     }
 
-
     window.requestAnimationFrame(() => {
-      console.log('request animation, scroll to: ', this.scrollId);
       document.getElementById(this.scrollId).scrollIntoView();
       this.scrollId = this.nextScrollId;
     });
     
-    // const scrolledY = window.scrollY;
-    // if (this.props.navigating === 'bottom') {
-    //   window.scroll(0, scrolledY)
-    // }
-    // // hit "To Top" button
-    // else if (this.props.navigating === 'top') {
-    //   // a little hack to expose the current offset
-    //   // line which is hidden behind the fixed header 
-    //   const headerHt = 270;
-    //   if(scrolledY){
-    //     window.scroll(0, scrolledY - headerHt);
-    //   }
-    // }
-    
   }
-
-
-  checkPosition() {
-    if (this.state.isTailing) {
-      this.scrollToBottom();
+  
+  scrollForNavigatonChange() {
+    if (this.props.positionChange === 'bottom') {
+      $('#log').scrollTop($('#log')[0].scrollHeight);
+    }
+    else if (this.props.positionChange === 'top') {
+      $('#log').scrollTop(0);
     }
   }
   
@@ -221,7 +178,7 @@ class BuildLog extends Component {
 
 BuildLog.propTypes = {
   log: PropTypes.array,
-  navigating: PropTypes.string,
+  positionChange: PropTypes.string,
   scrollToOffset: PropTypes.number,
   fetchingLog: PropTypes.bool,
   position: PropTypes.string,

--- a/BlazarUI/app/scripts/components/build/BuildLog.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildLog.jsx
@@ -34,15 +34,18 @@ class BuildLog extends Component {
   componentWillReceiveProps(nextProps) {
   
     const buildInProgress = nextProps.buildState === BuildStates.IN_PROGRESS;
+    const onDeck = buildIsOnDeck(nextProps.buildState);
+
+    if (!buildInProgress && onDeck) {
+      return;
+    }
     
-    // if (!buildInProgress) {
-    //   return;
-    // }
-    
+    // if we use navigation buttons to 
+    // navigate down to the bottom of the log
     if (buildInProgress && nextProps.log.fetchCount === 1 && nextProps.log.positionChange === 'bottom') {
       this.isTailing = true;
     }
-
+  
     // if we are at the top - remove the paging spinner
     if (nextProps.log.options.offset < nextProps.log.options.offsetLength) {
       this.showPagingSpinnerUp = false;

--- a/BlazarUI/app/scripts/components/build/BuildLog.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildLog.jsx
@@ -30,14 +30,14 @@ class BuildLog extends Component {
     this.scrollId = `offset-${this.props.log.currrentOffsetLine}`;
     this.scrollToBottom();
   }
-  
+
   componentWillReceiveProps(nextProps) {
   
     const buildInProgress = nextProps.buildState === BuildStates.IN_PROGRESS;
     
-    if (!buildInProgress) {
-      return;
-    }
+    // if (!buildInProgress) {
+    //   return;
+    // }
     
     if (buildInProgress && nextProps.log.fetchCount === 1 && nextProps.log.positionChange === 'bottom') {
       this.isTailing = true;
@@ -47,7 +47,8 @@ class BuildLog extends Component {
     if (nextProps.log.options.offset < nextProps.log.options.offsetLength) {
       this.showPagingSpinnerUp = false;
       this.showPagingSpinnerDown = true;
-    } else {
+    } 
+    else {
       this.showPagingSpinnerUp = true;
     }
     

--- a/BlazarUI/app/scripts/components/build/BuildLog.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildLog.jsx
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes, findDOMNode} from 'react';
 import $ from 'jquery';
 import {debounce} from 'underscore';
-import {events, humanizeText} from '../Helpers';
+import {events, humanizeText, buildIsOnDeck, buildIsInactve} from '../Helpers';
 import BuildLogLine from './BuildLogLine.jsx';
 import Collapsable from '../shared/Collapsable.jsx';
 import Loader from '../shared/Loader.jsx';
@@ -21,12 +21,13 @@ class BuildLog extends Component {
 
   componentDidMount() {
     this.scrollId = `offset-${this.props.currrentOffsetLine}`;
-
-    this.scrollToBottom();
     $('#log').on('scroll', this.handleScroll)
-  }
 
-  componentWillReceiveProps(nextProps) {
+    if (buildIsOnDeck(this.props.buildState)) {
+      return;
+    }
+    
+    this.scrollToBottom();    
   }
 
   componentDidUpdate(nextProps, nextState) {

--- a/BlazarUI/app/scripts/components/build/BuildLog.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildLog.jsx
@@ -43,9 +43,8 @@ class BuildLog extends Component {
       this.isTailing = true;
     }
 
-
     // if we are at the top - remove the paging spinner
-    if (nextProps.log.options.offset === 0) {
+    if (nextProps.log.options.offset < nextProps.log.options.offsetLength) {
       this.showPagingSpinnerUp = false;
       this.showPagingSpinnerDown = true;
     } else {

--- a/BlazarUI/app/scripts/components/build/BuildLog.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildLog.jsx
@@ -1,51 +1,192 @@
 import React, {Component, PropTypes, findDOMNode} from 'react';
 import $ from 'jquery';
-import utf8 from 'utf8';
-import {bindAll} from 'underscore';
+import {debounce} from 'underscore';
 import {events, humanizeText} from '../Helpers';
+import BuildLogLine from './BuildLogLine.jsx';
 import Collapsable from '../shared/Collapsable.jsx';
 import Loader from '../shared/Loader.jsx';
 import MutedMessage from '../shared/MutedMessage.jsx'
-import ScrollTo from '../shared/ScrollTo.jsx';
 import BuildStates from '../../constants/BuildStates';
+
 
 class BuildLog extends Component {
 
-  constructor() {
-    bindAll(this, 'handleScroll');
-    this.isTailing = true;
-  }
+  constructor(props, context) {
+    super(props, context);    
+    this.handleScroll = this.handleScroll.bind(this);
+    this.scrollId = 'offset-0';
 
-  componentDidMount() {
-    events.listenTo('scroll', this.handleScroll)
-  }
-
-  componentWillUnmount() {
-    events.removeListener('scroll', this.handleScroll)
-  }
-
-  handleScroll() {
-    if ($(window).scrollTop() == $(document).height()-$(window).height()) {
-      this.isTailing = true;
-    } else {
-      this.isTailing = false;
+    this.state = {
+      isTailing: this.props.fetchingLog,
+      isPaging: false,
+      hasPaged: false
     }
   }
-   
+  
+  
+  componentDidMount() {
+    this.scrollId = `offset-${this.props.currrentOffsetLine}`;
+    
+    console.log('did Mount, set scrollId: ', this.props.currrentOffsetLine);
+    this.scrollToBottom();
+    $('#log').on('scroll', this.handleScroll)
+  }
+
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      isPaging: false
+    });
+  }
+
   componentDidUpdate(nextProps, nextState) {
-    if (nextProps.buildState === BuildStates.IN_PROGRESS) {
+    console.log('Component Did Update');
+    
+    // store next scroll to value so we can set it
+    // set it after our requestAnimationFrame is complete
+    
+    // If navigating using the 'To Top' and 'To Bottom' buttons
+    if (this.props.navigating) {
+      this.nextScrollId = `offset-${this.props.scrollToOffset}`;
+    }
+    
+    else {
+      console.log('setting scrollId to: ', this.props.currrentOffsetLine);
+      this.nextScrollId = `offset-${this.props.currrentOffsetLine}`;
+    }
+
+    this.scrollToOffset();
+    // window.requestAnimationFrame(() => {
+    //   this.scrollToOffset();
+    // });
+    
+
+
+    // Active builds... --> check position
+    // if (nextProps.buildState === BuildStates.IN_PROGRESS) {
+  }
+  
+  componentWillUnmount() {
+    $('#log').off('scroll', this.handleScroll)
+  }
+  
+  handlePageUp() {
+    if (!this.state.hasPaged) {
+      this.props.pageUp();
+    }
+  }
+
+  handleScroll() {  
+
+    const logPosition = $('#log').scrollTop();
+    const logHeight = $('#log')[0].scrollHeight - 240
+    
+    if (logPosition === logHeight ) {
+      if (this.props.buildState === BuildStates.IN_PROGRESS) {
+        this.setState({
+          isTailing: true
+        });
+      }
+    } 
+    
+    // at top of page
+    else if ( logPosition <= 30 && !this.state.isPaging) {
+      console.log('handle Page up');
+      this.handlePageUp();
+        this.setState({
+          isPaging: true
+        });
+    }
+    
+    else {
+      if (this.props.buildState === BuildStates.IN_PROGRESS) {
+        this.setState({
+          isTailing: false
+        });
+      }
+    }
+    
+    
+    // // at bottom of page
+    // if ($(window).scrollTop() === $(document).height() - $(window).height()  ) {
+    //   if (this.props.buildState === BuildStates.IN_PROGRESS) {
+    //     this.setState({
+    //       isTailing: true
+    //     });
+    //   }
+    // } 
+    // 
+    // // at top of page
+    // else if ($(window).scrollTop() <= 30 && !this.state.isPaging) {
+    //   this.handlePageUp();
+    //   // show loader at top of build log
+    //   this.setState({
+    //     isPaging: true
+    //   });
+    // }
+    // 
+    // else {
+    //   if (this.props.buildState === BuildStates.IN_PROGRESS) {
+    //     this.setState({
+    //       isTailing: false,
+    //       isPaging: false
+    //     });
+    //   }
+    // }
+    
+    
+  }
+  
+  
+  
+  
+  
+  scrollToOffset() {
+    if (!this.scrollId) {
+      return;
+    }
+
+
+    window.requestAnimationFrame(() => {
+      console.log('request animation, scroll to: ', this.scrollId);
+      document.getElementById(this.scrollId).scrollIntoView();
+      this.scrollId = this.nextScrollId;
+    });
+    
+    // const scrolledY = window.scrollY;
+    // if (this.props.navigating === 'bottom') {
+    //   window.scroll(0, scrolledY)
+    // }
+    // // hit "To Top" button
+    // else if (this.props.navigating === 'top') {
+    //   // a little hack to expose the current offset
+    //   // line which is hidden behind the fixed header 
+    //   const headerHt = 270;
+    //   if(scrolledY){
+    //     window.scroll(0, scrolledY - headerHt);
+    //   }
+    // }
+    
+  }
+
+
+  checkPosition() {
+    if (this.state.isTailing) {
       this.scrollToBottom();
     }
   }
-
+  
   scrollToBottom() {
-    if (this.isTailing) {
-      window.scrollTo(0, document.body.scrollHeight);
-    }
+    window.requestAnimationFrame(() => {
+      $('#log').scrollTop($('#log')[0].scrollHeight - 240);
+    });
   }
 
-  getLogMarkup() {
-    return {__html: utf8.decode(this.props.log)};
+  generateLines() {
+    return this.props.log.map((line, i) => {
+      return (
+        <BuildLogLine offset={line.offset} text={line.text} key={i} />
+      );
+    });
   }
 
   render() {
@@ -56,40 +197,35 @@ class BuildLog extends Component {
       <Loader align='top-center' />
     }
 
-    if (!this.props.log || typeof this.props.log !== 'string' || noBuildLog) {
-      return <div />;
+    if (!this.props.log || noBuildLog) {
+      return null;
     }
 
-    if (this.props.fetchingLog) {
+    if (this.state.isTailing && this.props.buildState === BuildStates.IN_PROGRESS) {
       spinner = (
         <Loader align='left' roomy={true} />
       );
-
     }
 
     return (
-      <Collapsable 
-        header='Build Log'
-        initialToggleStateOpen={true}
-        disableToggle={true}
+      <pre id='log' 
+        ref='log'
+        className='build-log' 
       >
-        <div className='build-log-container'>
-          <pre id='log' 
-            ref='log'
-            className='build-log' 
-            dangerouslySetInnerHTML={this.getLogMarkup()} 
-          />
-          {spinner}
-          <ScrollTo className='build-log-scroll' />
-        </div>
-      </Collapsable>
+        {this.generateLines()}
+        {spinner}
+      </pre>
     );
   }
 }
 
 BuildLog.propTypes = {
-  log: PropTypes.string,
+  log: PropTypes.array,
+  navigating: PropTypes.string,
+  scrollToOffset: PropTypes.number,
   fetchingLog: PropTypes.bool,
+  position: PropTypes.string,
+  pageUp: PropTypes.func,
   buildState: PropTypes.string,
   isBuilding: PropTypes.bool,
   loading: PropTypes.bool

--- a/BlazarUI/app/scripts/components/build/BuildLog.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildLog.jsx
@@ -21,6 +21,7 @@ class BuildLog extends Component {
 
   componentDidMount() {
     this.scrollId = `offset-${this.props.currrentOffsetLine}`;
+
     this.scrollToBottom();
     $('#log').on('scroll', this.handleScroll)
   }
@@ -148,6 +149,15 @@ class BuildLog extends Component {
   }
 
   generateLines() {
+    if (this.props.buildState === BuildStates.LAUNCHING || this.props.buildState === BuildStates.QUEUED) {
+      return (
+        <div>
+          <BuildLogLine text='Polling for updates...' />
+          <Loader align='left' roomy={true} />
+        </div>
+      );
+    }
+
     return this.props.log.map((line, i) => {
       return (
         <BuildLogLine offset={line.offset} text={line.text} key={i} />

--- a/BlazarUI/app/scripts/components/build/BuildLogLine.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildLogLine.jsx
@@ -1,0 +1,18 @@
+import React, {Component, PropTypes} from 'react';
+
+class BuildLogLine extends Component {
+
+  render() {
+    const offset = `offset-${this.props.offset}`;
+    return (
+      <p id={offset} className='log-line'>{this.props.text}</p>
+    );
+  }
+}
+
+BuildLogLine.propTypes = {
+  text: PropTypes.string,
+  offset: PropTypes.number
+};
+
+export default BuildLogLine;

--- a/BlazarUI/app/scripts/components/build/BuildLogNavigation.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildLogNavigation.jsx
@@ -8,7 +8,7 @@ class BuildLogNavigation extends Component {
 
   handleNavClick(e) {
     const position = dataTagValue(e, 'position');
-    this.props.navigateLogChange(position);
+    this.props.changeOffsetWithNavigation(position);
   }
 
   render() {
@@ -22,7 +22,7 @@ class BuildLogNavigation extends Component {
 }
 // 
 BuildLogNavigation.propTypes = {
-  navigateLogChange: PropTypes.func.isRequired
+  changeOffsetWithNavigation: PropTypes.func.isRequired
 };
 
 export default BuildLogNavigation;

--- a/BlazarUI/app/scripts/components/build/BuildLogNavigation.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildLogNavigation.jsx
@@ -3,12 +3,31 @@ import {dataTagValue} from '../Helpers';
 import BuildStates from '../../constants/BuildStates';
 
 class BuildLogNavigation extends Component {
-  constructor() {
+
+  constructor(props) {
+    super(props);
     this.handleNavClick = this.handleNavClick.bind(this);
+    
+    this.state = {
+      topDisabled: this.props.loading,
+      bottomDisabled: this.props.loading
+    }
+  }
+  
+  componentWillReceiveProps(nextProps) {
+    this.setState({
+      topDisabled: nextProps.loading,
+      bottomDisabled: nextProps.loading
+    })
   }
 
   handleNavClick(e) {
     const position = dataTagValue(e, 'position');
+
+    this.setState({
+      [position + 'Disabled']: true
+    })
+
     this.props.changeOffsetWithNavigation(position);
   }
 
@@ -19,8 +38,8 @@ class BuildLogNavigation extends Component {
 
     return (
       <nav className='text-right'>
-        <button data-position='top' onClick={this.handleNavClick} className='log-nav-btn btn btn-default'>To Top</button>
-        <button data-position='bottom' onClick={this.handleNavClick} className='log-nav-btn btn btn-default'>To Bottom</button>
+        <button data-position='top' disabled={this.state.topDisabled} onClick={this.handleNavClick} className='log-nav-btn btn btn-default'>To Top</button>
+        <button data-position='bottom' disabled={this.state.bottomDisabled} onClick={this.handleNavClick} className='log-nav-btn btn btn-default'>To Bottom</button>
       </nav>
     );
   }

--- a/BlazarUI/app/scripts/components/build/BuildLogNavigation.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildLogNavigation.jsx
@@ -1,5 +1,6 @@
 import React, {Component, PropTypes} from 'react';
 import {dataTagValue} from '../Helpers';
+import BuildStates from '../../constants/BuildStates';
 
 class BuildLogNavigation extends Component {
   constructor() {
@@ -12,6 +13,10 @@ class BuildLogNavigation extends Component {
   }
 
   render() {
+    if (this.props.buildState === BuildStates.LAUNCHING || this.props.buildState === BuildStates.QUEUED) {
+      return null;
+    }
+
     return (
       <nav className='text-right'>
         <button data-position='top' onClick={this.handleNavClick} className='log-nav-btn btn btn-default'>To Top</button>

--- a/BlazarUI/app/scripts/components/build/BuildLogNavigation.jsx
+++ b/BlazarUI/app/scripts/components/build/BuildLogNavigation.jsx
@@ -1,0 +1,28 @@
+import React, {Component, PropTypes} from 'react';
+import {dataTagValue} from '../Helpers';
+
+class BuildLogNavigation extends Component {
+  constructor() {
+    this.handleNavClick = this.handleNavClick.bind(this);
+  }
+
+  handleNavClick(e) {
+    const position = dataTagValue(e, 'position');
+    this.props.navigateLogChange(position);
+  }
+
+  render() {
+    return (
+      <nav className='text-right'>
+        <button data-position='top' onClick={this.handleNavClick} className='log-nav-btn btn btn-default'>To Top</button>
+        <button data-position='bottom' onClick={this.handleNavClick} className='log-nav-btn btn btn-default'>To Bottom</button>
+      </nav>
+    );
+  }
+}
+// 
+BuildLogNavigation.propTypes = {
+  navigateLogChange: PropTypes.func.isRequired
+};
+
+export default BuildLogNavigation;

--- a/BlazarUI/app/scripts/components/build/CancelBuildButton.jsx
+++ b/BlazarUI/app/scripts/components/build/CancelBuildButton.jsx
@@ -58,7 +58,7 @@ class CancelBuildButton extends Component {
     
     if (this.props.buildCancelTriggered || this.state.cancelling) {
       return (
-        <div>
+        <div className='text-right'>
           <Button bsStyle="danger" disabled>
             <Icon for="spinner" /> Cancelling
           </Button>
@@ -67,7 +67,7 @@ class CancelBuildButton extends Component {
       );
     } else {
       return (
-        <div>
+        <div className='text-right'>
           <Button bsStyle="danger" onClick={this.handleCancelBuild}>
             Cancel Build
           </Button>

--- a/BlazarUI/app/scripts/components/build/CancelBuildButton.jsx
+++ b/BlazarUI/app/scripts/components/build/CancelBuildButton.jsx
@@ -71,8 +71,8 @@ class CancelBuildButton extends Component {
       );
     } else {
       return (
-        <div className='text-right'>
-          <Button bsStyle="danger" onClick={this.handleCancelBuild}>
+        <div className='cancel-build-button text-right'>
+          <Button bsSize='xsmall' bsStyle='danger' onClick={this.handleCancelBuild}>
             Cancel Build
           </Button>
           {this.cancelModal()}

--- a/BlazarUI/app/scripts/components/build/CancelBuildButton.jsx
+++ b/BlazarUI/app/scripts/components/build/CancelBuildButton.jsx
@@ -34,7 +34,11 @@ class CancelBuildButton extends Component {
     return (
       <Modal show={this.state.showModal} onHide={this.closeCancelModal}>
         <Modal.Header closeButton>
-          <Modal.Title>Are you sure you want to cancel build #{this.props.build.build.id}</Modal.Title>
+          <Modal.Title>
+            Are you sure you want to cancel 
+            <strong> build #{this.props.build.build.buildNumber}</strong> {' '}
+            for module <strong>{this.props.build.module.name}</strong>.
+          </Modal.Title>
         </Modal.Header>
         <Modal.Footer>
           <Button onClick={this.closeCancelModal}>No, nevermind</Button>

--- a/BlazarUI/app/scripts/components/repo/BranchesTableRow.jsx
+++ b/BlazarUI/app/scripts/components/repo/BranchesTableRow.jsx
@@ -55,7 +55,9 @@ class BranchesTableRow extends Component {
     }
 
     let sha;
-    const build = inProgressBuild ? inProgressBuild : lastBuild ? lastBuild : pendingBuild;
+    const build = inProgressBuild ? inProgressBuild : pendingBuild ? pendingBuild : lastBuild;
+    
+    console.log('build: ', build);
     
     if (build.sha !== undefined) {
       sha = <Sha gitInfo={gitInfo} build={build} />;
@@ -77,7 +79,7 @@ class BranchesTableRow extends Component {
           <Link to={module.blazarPath.module}>{module.name}</Link>
         </td>
         <td className='build-result-link'>
-          <Link to={lastBuild.blazarPath}>
+          <Link to={build.blazarPath}>
             {this.getBuildResult(build)}
             {build.buildNumber}
           </Link>

--- a/BlazarUI/app/scripts/components/repo/BranchesTableRow.jsx
+++ b/BlazarUI/app/scripts/components/repo/BranchesTableRow.jsx
@@ -57,8 +57,6 @@ class BranchesTableRow extends Component {
     let sha;
     const build = inProgressBuild ? inProgressBuild : pendingBuild ? pendingBuild : lastBuild;
     
-    console.log('build: ', build);
-    
     if (build.sha !== undefined) {
       sha = <Sha gitInfo={gitInfo} build={build} />;
     }

--- a/BlazarUI/app/scripts/components/shared/AjaxErrorAlert.jsx
+++ b/BlazarUI/app/scripts/components/shared/AjaxErrorAlert.jsx
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
 import Alert from 'react-bootstrap/lib/Alert';
 
-class ErrorAlert extends Component {
+class AjaxErrorAlert extends Component {
 
   render() {    
     if (!this.props.error) {
@@ -17,8 +17,8 @@ class ErrorAlert extends Component {
   }
 }
 
-ErrorAlert.propTypes = {
+AjaxErrorAlert.propTypes = {
   error: PropTypes.node
 };
 
-export default ErrorAlert;
+export default AjaxErrorAlert;

--- a/BlazarUI/app/scripts/components/shared/GenericErrorMessage.jsx
+++ b/BlazarUI/app/scripts/components/shared/GenericErrorMessage.jsx
@@ -1,0 +1,43 @@
+import React, {Component, PropTypes} from 'react';
+import Alert from 'react-bootstrap/lib/Alert';
+
+class GenericErrorMessage extends Component {
+
+  getSeverity() {
+    switch (this.props.severity) {
+      case 'high':
+        return 'danger'
+
+      case 'medium':
+        return 'warning'
+
+      case 'low':
+        return 'info'
+
+      default:
+        return 'danger'
+    }
+  }
+
+  render() {
+    if (!this.props.message) {
+      return null;
+    }
+
+    return (
+      <Alert bsStyle={this.getSeverity()}>
+        <p>{this.props.message}</p>
+      </Alert>
+    );
+  }
+}
+
+GenericErrorMessage.defaultProps = {
+  severity: 'high'
+}
+
+GenericErrorMessage.propTypes = {
+  message: PropTypes.node
+};
+
+export default GenericErrorMessage;

--- a/BlazarUI/app/scripts/components/shared/SearchFilter.jsx
+++ b/BlazarUI/app/scripts/components/shared/SearchFilter.jsx
@@ -16,7 +16,6 @@ class SearchFilter extends Component {
     this.handleSearchDebounced = debounce(function () {
       this.props.onChange(this.refs.searchFilterInput.getDOMNode().value);
     }, 250);
-    
   }
     
   componentDidMount() {

--- a/BlazarUI/app/scripts/models/Log.js
+++ b/BlazarUI/app/scripts/models/Log.js
@@ -13,21 +13,48 @@ class Log extends Model {
     return `${config.apiRoot}/build/${this.options.buildNumber}/log?offset=${this.options.offset}`;
   }
   
-  parse() {    
-    if (this.isPaging) {
+  parse() {
+    // keep track of if we've loaded the last page
+    if (this.options.offset === this.options.lastOffset) {
+      this.endOfLogLoaded = true;
+    }
+
+    // paging up
+    if (this.isPaging && (this.positionChange === 'top' || this.direction === 'up')  ) {
       const newLogLines = this.formatLog();
       this.logLines = newLogLines.concat(this.logLines);
     }
-
+    // initial offset load or paging down
     else {
       this.logLines = this.logLines.concat(this.formatLog());
     }
   }
-  
-  pageUp() {
-    console.log('pageUp time. Current offset: ', this.options.offset);
+
+  incrementPage() {
+    this.currentPage += 1;
+  }
+
+  decrementPage() {
+    this.currentPage -= 1;
+  }
+
+  pageLog(direction) {
     this.isPaging = true;
-    this.options.offset = Math.max(this.options.offset - config.offsetLength, 0);
+    this.previousOffset = this.options.offset;
+
+    if (direction === 'up') {
+      this.options.offset = Math.max(this.options.offset - config.offsetLength, 0);
+    }
+
+    else {
+      this.options.offset = Math.min(this.options.offset + 90000, this.options.lastOffset);
+      // if we've loaded a partial offset
+      if (this.options.offset < 90000 && this.options.offset > 0) {
+        this.options.offset = 90000;
+        this.endOfLogLoaded = true;
+      }
+    }
+
     return this;
   }
   
@@ -48,13 +75,23 @@ class Log extends Model {
       return "<p class='roomy-xy'>Error loading build log. Please check your console for more detail.</p>";
     }
 
-    let offsetRunningTotal = this.options.offset;    
+    let offsetRunningTotal = this.options.offset;
     const NEW_LINE = '\n';
-    
+  
     // To Do:
+    // use bytes not character length
     // omit last line
     // omit the first (incomplete) element unless we're at the beginning of the file
-    const splitLines = this.jqXHR.responseJSON.data.split(NEW_LINE);
+    let logData = this.jqXHR.responseJSON.data;
+
+    // If offset is less that 90000 when paging up, 
+    // we need to remove any duplicate lines
+    // TO DO: trim is not cleanly cutting the line    
+    if (this.previousOffset < 90000 && this.direction === 'up' && !this.hasNavigatedWithButtons) {
+      logData = logData.substring(0, logData.length - (90000 - this.previousOffset))
+    }
+    
+    const splitLines = logData.split(NEW_LINE);
 
     return splitLines.map((line, i) => {
       if (i === 0) {
@@ -64,8 +101,7 @@ class Log extends Model {
       if (i === splitLines.length - 1) {
         this.lastOffsetLine = offsetRunningTotal + line.length;
       }
-      // To Do
-      // use byte size not character length
+
       return {
         text: line,
         offset: offsetRunningTotal += line.length

--- a/BlazarUI/app/scripts/models/Log.js
+++ b/BlazarUI/app/scripts/models/Log.js
@@ -144,8 +144,8 @@ class Log extends Model {
 
     // If offset is less than our offsetLength when scrolling up,
     // and we havent used the 'To Top' navigation button
-    // we need to omit any overlap from last fetch..
-    if (this.previousOffset < config.offsetLength && this.direction === 'up' && this.options.offset !== 0) {
+    // we need to omit any overlap from last fetch..    
+    if (this.options.offset < config.offsetLength && this.direction === 'up') {
       logData = logData.substring(0, this.getByteLength(logData) - (config.offsetLength - this.previousOffset))
     }
 

--- a/BlazarUI/app/scripts/models/Log.js
+++ b/BlazarUI/app/scripts/models/Log.js
@@ -1,26 +1,77 @@
 /*global config*/
 import Model from './Model';
+// import utf8 from 'utf8';
 
 class Log extends Model {
+  
+  constructor(options) {
+    this.logLines = [];
+    super(options);
+  }
 
   url() {
     return `${config.apiRoot}/build/${this.options.buildNumber}/log?offset=${this.options.offset}`;
   }
+  
+  parse() {    
+    if (this.isPaging) {
+      const newLogLines = this.formatLog();
+      this.logLines = newLogLines.concat(this.logLines);
+    }
 
-  formatLog(jqxhr) {
+    else {
+      this.logLines = this.logLines.concat(this.formatLog());
+    }
+  }
+  
+  pageUp() {
+    console.log('pageUp time. Current offset: ', this.options.offset);
+    this.isPaging = true;
+    this.options.offset = Math.max(this.options.offset - config.offsetLength, 0);
+    return this;
+  }
+  
+  reset() {
+    this.logLines = [];
+    return this;
+  }
+  
+  setOffset(offset) {
+    this.options.currentOffset = offset;
+    this.options.offset = offset;
+    return this;
+  }
 
-    if (jqxhr.status !== 200) {
-      console.warn(jqxhr);
+  formatLog() {
+    if (this.jqXHR.status !== 200) {
+      console.warn(this.jqXHR);
       return "<p class='roomy-xy'>Error loading build log. Please check your console for more detail.</p>";
     }
 
+    let offsetRunningTotal = this.options.offset;    
     const NEW_LINE = '\n';
-    return jqxhr.responseJSON.data.split(NEW_LINE).map((line) => {
-      if (line.length === 0) {
-        return null;
+    
+    // To Do:
+    // omit last line
+    // omit the first (incomplete) element unless we're at the beginning of the file
+    const splitLines = this.jqXHR.responseJSON.data.split(NEW_LINE);
+
+    return splitLines.map((line, i) => {
+      if (i === 0) {
+        this.currrentOffsetLine = offsetRunningTotal + line.length;
       }
-      return `<p class='log-line'>${line}</p>`;
-    }).join('');
+      
+      if (i === splitLines.length - 1) {
+        this.lastOffsetLine = offsetRunningTotal + line.length;
+      }
+      // To Do
+      // use byte size not character length
+      return {
+        text: line,
+        offset: offsetRunningTotal += line.length
+      }
+      
+    });
 
   }
 

--- a/BlazarUI/app/scripts/models/Log.js
+++ b/BlazarUI/app/scripts/models/Log.js
@@ -1,24 +1,54 @@
 /*global config*/
 import Model from './Model';
-// import utf8 from 'utf8';
+import BuildStates from '../constants/BuildStates';
+import utf8 from 'utf8';
 
 class Log extends Model {
   
   constructor(options) {
     this.logLines = [];
+    this.hasFetched = false;
     super(options);
   }
 
   url() {
-    return `${config.apiRoot}/build/${this.options.buildNumber}/log?offset=${this.options.offset}`;
+    console.log('fetching: ', this.options.offset);
+    return `${config.apiRoot}/build/${this.options.buildNumber}/log?offset=${this.options.offset}&length=50000`;
   }
   
-  parse() {
-    // keep track of if we've loaded the last page
-    if (this.options.offset === this.options.lastOffset) {
-      this.endOfLogLoaded = true;
+  parseInProgressBuild() {    
+    // if (this.nextOffset === this.data.nextOffset) {
+    //   console.log('no change in log');
+    //   return;
+    // }
+    
+
+    // initial load
+    if (!this.hasFetched) {
+      this.logLines = this.formatLog();
+      this.hasFetched = true;
+    }
+    
+    // paging up
+    else if (this.isPaging && (this.positionChange === 'top' || this.direction === 'up')) {
+      const newLogLines = this.formatLog();
+      this.logLines = newLogLines.concat(this.logLines);
     }
 
+    else {
+      this.logLines = this.logLines.concat(this.formatLog());
+    }
+    
+    // else {
+    //   console.log('more to go...');
+    //   this.logLines = this.logLines.concat(this.formatLog());
+    //   this.setOffset()
+    //   
+    // }
+
+  }
+  
+  parseInactiveBuild() {
     // paging up
     if (this.isPaging && (this.positionChange === 'top' || this.direction === 'up')  ) {
       const newLogLines = this.formatLog();
@@ -28,6 +58,22 @@ class Log extends Model {
     else {
       this.logLines = this.logLines.concat(this.formatLog());
     }
+
+  }
+  
+  parse() {
+    if (this.options.buildState === BuildStates.IN_PROGRESS) {
+      this.parseInProgressBuild();
+    }
+    else {
+      this.parseInactiveBuild();
+    }
+
+    // keep track of if we've loaded the last page
+    if (this.options.offset === this.options.lastOffset) {
+      this.endOfLogLoaded = true;
+    }
+
   }
 
   incrementPage() {
@@ -39,18 +85,30 @@ class Log extends Model {
   }
 
   pageLog(direction) {
+    console.log('pageLog');
     this.isPaging = true;
     this.previousOffset = this.options.offset;
 
     if (direction === 'up') {
-      this.options.offset = Math.max(this.options.offset - config.offsetLength, 0);
+      
+      // if in progress build
+      if (this.options.buildState === BuildStates.IN_PROGRESS) {
+        this.options.offset = Math.max(this.options.offset - config.offsetLength, 0);        
+        // this.options.offset = Math.max(this.options.startingOffset - config.offsetLength, 0);
+        console.log('set offset: ', this.options.offset);
+      }
+      // finished build
+      else {
+        this.options.offset = Math.max(this.options.offset - config.offsetLength, 0);        
+      }
+
     }
 
     else {
-      this.options.offset = Math.min(this.options.offset + 90000, this.options.lastOffset);
+      this.options.offset = Math.min(this.options.offset + config.offsetLength, this.options.lastOffset);
       // if we've loaded a partial offset
-      if (this.options.offset < 90000 && this.options.offset > 0) {
-        this.options.offset = 90000;
+      if (this.options.offset < config.offsetLength && this.options.offset > 0) {        
+        this.options.offset = config.offsetLength;
         this.endOfLogLoaded = true;
       }
     }
@@ -69,6 +127,23 @@ class Log extends Model {
     return this;
   }
 
+  getByteLength(normal_val) {
+      // Force string type
+      normal_val = String(normal_val);
+
+      let byteLen = 0;
+      for (let i = 0; i < normal_val.length; i++) {
+          const c = normal_val.charCodeAt(i);
+          byteLen += c < (1 <<  7) ? 1 :
+                     c < (1 << 11) ? 2 :
+                     c < (1 << 16) ? 3 :
+                     c < (1 << 21) ? 4 :
+                     c < (1 << 26) ? 5 :
+                     c < (1 << 31) ? 6 : Number.NaN;
+      }
+      return byteLen;
+  }
+
   formatLog() {
     if (this.jqXHR.status !== 200) {
       console.warn(this.jqXHR);
@@ -76,39 +151,39 @@ class Log extends Model {
     }
 
     let offsetRunningTotal = this.options.offset;
+
     const NEW_LINE = '\n';
-  
-    // To Do:
-    // use bytes not character length
-    // omit last line
-    // omit the first (incomplete) element unless we're at the beginning of the file
     let logData = this.jqXHR.responseJSON.data;
 
-    // If offset is less that 90000 when paging up, 
-    // we need to remove any duplicate lines
-    // TO DO: trim is not cleanly cutting the line    
-    if (this.previousOffset < 90000 && this.direction === 'up' && !this.hasNavigatedWithButtons) {
-      logData = logData.substring(0, logData.length - (90000 - this.previousOffset))
+    // If offset is less than our offsetLength when paging up,
+    // we need to omit any overlap from last fetch
+    if (this.previousOffset < config.offsetLength && this.direction === 'up' && !this.hasNavigatedWithButtons) {
+      logData = logData.substring(0, this.getByteLength(logData) - (config.offsetLength - this.previousOffset))
     }
-    
-    const splitLines = logData.split(NEW_LINE);
 
+    if (logData.length === 0) {
+      return [];
+    }
+
+    const splitLines = logData.split(NEW_LINE);
+    
     return splitLines.map((line, i) => {
       if (i === 0) {
-        this.currrentOffsetLine = offsetRunningTotal + line.length;
+        this.currrentOffsetLine = offsetRunningTotal + this.getByteLength(line);
       }
       
       if (i === splitLines.length - 1) {
-        this.lastOffsetLine = offsetRunningTotal + line.length;
+        this.lastOffsetLine = offsetRunningTotal + this.getByteLength(length);
       }
 
       return {
-        text: line,
-        offset: offsetRunningTotal += line.length
+        text:  utf8.decode(line),
+        offset: offsetRunningTotal += this.getByteLength(line)
       }
-      
-    });
-
+  });
+  // omit last line that may be incomplete
+  // }).splice(0, splitLines.length - 1);
+    
   }
 
 }

--- a/BlazarUI/app/scripts/models/Log.js
+++ b/BlazarUI/app/scripts/models/Log.js
@@ -2,7 +2,7 @@
 import Model from './Model';
 import BuildStates from '../constants/BuildStates';
 import utf8 from 'utf8';
-import {rest, initial, first, last, find} from 'underscore';
+import {rest, initial, first, last, find, compact} from 'underscore';
 
 class Log extends Model {
   
@@ -72,15 +72,17 @@ class Log extends Model {
       else {
         const tempLast = last(newLogLines);
         newLogLines = initial(newLogLines);
-        // append any extra text to first log line
-        newLogLines[0].text = this.lastLine.text + newLogLines[0].text;
+        
+        // append any extra text to first log line            
+        if (newLogLines[0] && this.lastLine) {
+          newLogLines[0].text = this.lastLine.text + newLogLines[0].text;
+        }
+
         this.lastLine = tempLast;
       }
 
       this.logLines = this.logLines.concat(newLogLines);
     }
-
-
   }
 
   pageLog(direction) {
@@ -88,7 +90,7 @@ class Log extends Model {
     this.previousOffset = this.options.offset;
 
     if (direction === 'up') {
-      // Builds In Progress
+      // Builds In Progresse
       if (this.options.buildState === BuildStates.IN_PROGRESS) {
         this.options.offset = Math.max(this.runningOffset - config.offsetLength - 1, 0);
         this.runningOffset -= config.offsetLength;
@@ -106,7 +108,6 @@ class Log extends Model {
         this.options.offset = config.offsetLength + 1;
       }
       else {
-        // this.options.offset = Math.min(this.options.offset + config.offsetLength, this.options.lastOffset);
         this.options.offset = this.options.offset + config.offsetLength + 1;
         
         if ((this.options.offset + config.offsetLength + 1) > this.options.logSize) {
@@ -115,10 +116,10 @@ class Log extends Model {
 
       }
       // if we've loaded a partial offset
-      // if (this.options.offset < config.offsetLength  && this.options.offset > 0) {
-      //   this.options.offset = config.offsetLength;
-      //   this.endOfLogLoaded = true;
-      // }
+      if (this.options.offset < config.offsetLength  && this.options.offset > 0) {
+        this.options.offset = config.offsetLength;
+        this.endOfLogLoaded = true;
+      }
     }
 
     return this;
@@ -176,8 +177,7 @@ class Log extends Model {
       return [];
     }
 
-    const splitLines = logData.split(NEW_LINE);
-    
+    const splitLines = compact(logData.split(NEW_LINE));
     return splitLines.map((line, i) => {
       // store second line because we may chop off the first
       if (i === 1) {

--- a/BlazarUI/app/scripts/models/Log.js
+++ b/BlazarUI/app/scripts/models/Log.js
@@ -7,44 +7,33 @@ class Log extends Model {
   
   constructor(options) {
     this.logLines = [];
+    this.fetchCount = 0;
     this.hasFetched = false;
+    this.runningOffset = options.startingOffset;
     super(options);
   }
 
   url() {
-    console.log('fetching: ', this.options.offset);
     return `${config.apiRoot}/build/${this.options.buildNumber}/log?offset=${this.options.offset}&length=50000`;
   }
   
-  parseInProgressBuild() {    
-    // if (this.nextOffset === this.data.nextOffset) {
-    //   console.log('no change in log');
-    //   return;
-    // }
-    
-
+  parseInProgressBuild() {
     // initial load
     if (!this.hasFetched) {
       this.logLines = this.formatLog();
       this.hasFetched = true;
     }
     
-    // paging up
+    // paging up - prepend log lines
     else if (this.isPaging && (this.positionChange === 'top' || this.direction === 'up')) {
       const newLogLines = this.formatLog();
       this.logLines = newLogLines.concat(this.logLines);
     }
 
+    // paging dow - append log lines
     else {
       this.logLines = this.logLines.concat(this.formatLog());
     }
-    
-    // else {
-    //   console.log('more to go...');
-    //   this.logLines = this.logLines.concat(this.formatLog());
-    //   this.setOffset()
-    //   
-    // }
 
   }
   
@@ -62,6 +51,7 @@ class Log extends Model {
   }
   
   parse() {
+    this.fetchCount++;
     if (this.options.buildState === BuildStates.IN_PROGRESS) {
       this.parseInProgressBuild();
     }
@@ -76,36 +66,31 @@ class Log extends Model {
 
   }
 
-  incrementPage() {
-    this.currentPage += 1;
-  }
-
-  decrementPage() {
-    this.currentPage -= 1;
-  }
-
   pageLog(direction) {
-    console.log('pageLog');
     this.isPaging = true;
     this.previousOffset = this.options.offset;
 
     if (direction === 'up') {
-      
-      // if in progress build
+      // Builds In Progress
       if (this.options.buildState === BuildStates.IN_PROGRESS) {
-        this.options.offset = Math.max(this.options.offset - config.offsetLength, 0);        
-        // this.options.offset = Math.max(this.options.startingOffset - config.offsetLength, 0);
-        console.log('set offset: ', this.options.offset);
+        this.options.offset = Math.max(this.runningOffset - config.offsetLength, 0);
+        this.runningOffset -= config.offsetLength;
       }
-      // finished build
+      // Finished Builds
       else {
-        this.options.offset = Math.max(this.options.offset - config.offsetLength, 0);        
+        this.options.offset = Math.max(this.options.offset - config.offsetLength, 0);
+      }
+    }
+  
+    else if (direction === 'down') {      
+      
+      if (this.options.offset === 0) {
+        this.options.offset = config.offsetLength;
+      }
+      else {
+        this.options.offset = Math.min(this.options.offset + config.offsetLength, this.options.lastOffset);
       }
 
-    }
-
-    else {
-      this.options.offset = Math.min(this.options.offset + config.offsetLength, this.options.lastOffset);
       // if we've loaded a partial offset
       if (this.options.offset < config.offsetLength && this.options.offset > 0) {        
         this.options.offset = config.offsetLength;
@@ -117,6 +102,8 @@ class Log extends Model {
   }
   
   reset() {
+    this.fetchCount = 0;
+    this.hasFetched = false;
     this.logLines = [];
     return this;
   }
@@ -155,9 +142,10 @@ class Log extends Model {
     const NEW_LINE = '\n';
     let logData = this.jqXHR.responseJSON.data;
 
-    // If offset is less than our offsetLength when paging up,
-    // we need to omit any overlap from last fetch
-    if (this.previousOffset < config.offsetLength && this.direction === 'up' && !this.hasNavigatedWithButtons) {
+    // If offset is less than our offsetLength when scrolling up,
+    // and we havent used the 'To Top' navigation button
+    // we need to omit any overlap from last fetch..
+    if (this.previousOffset < config.offsetLength && this.direction === 'up' && this.options.offset !== 0) {
       logData = logData.substring(0, this.getByteLength(logData) - (config.offsetLength - this.previousOffset))
     }
 

--- a/BlazarUI/app/scripts/models/LogSize.js
+++ b/BlazarUI/app/scripts/models/LogSize.js
@@ -1,0 +1,13 @@
+/*global config*/
+import Model from './Model';
+
+class LogSize extends Model {
+
+  // to do: rename this buildId - buildNumber is something else
+  url() {
+    return `${config.apiRoot}/build/${this.options.buildNumber}/log/size`;
+  }
+
+}
+
+export default LogSize;

--- a/BlazarUI/app/scripts/stores/buildStore.js
+++ b/BlazarUI/app/scripts/stores/buildStore.js
@@ -20,10 +20,13 @@ const BuildStore = Reflux.createStore({
     });
   },
 
-  loadBuildError(error) {
+  loadBuildError(detail) {
+    this.build = detail.build;
+    
     this.trigger({
-      error: error,
-      loading: false
+      error: detail.responseText,
+      loading: false,
+      build: this.build
     });
   },
 
@@ -50,9 +53,9 @@ const BuildStore = Reflux.createStore({
     });
   },
   
-  loadBuildCancelError(error) {    
+  loadGenericErrorMessage(error) {    
     this.trigger({
-      loadBuildCancelError: error
+      error: error
     });
   },
 

--- a/BlazarUI/app/scripts/utils/progress.js
+++ b/BlazarUI/app/scripts/utils/progress.js
@@ -21,7 +21,7 @@ function progress(startTimestamp, history) {
 function _filterOutliers(durations) {
   const values = durations.concat();
 
-  if (durations.length < 3) {
+  if (durations.length < 4) {
     return durations;
   }
 

--- a/BlazarUI/app/stylus/components/build-detail.styl
+++ b/BlazarUI/app/stylus/components/build-detail.styl
@@ -3,7 +3,9 @@
 build-status(color)
   .build-detail-header
     border-bottom 1px solid color
-
+    .headline-icon
+      margin 0 5px
+    
   .build-detail-footer
     border-top 1px solid color
 
@@ -42,7 +44,7 @@ build-status(color)
   word-wrap break-word
   background inherit
   border none
-  padding 0 5px
+  padding 0 10px
   margin 0
   color $gray-darker
   font-size 12px
@@ -50,7 +52,7 @@ build-status(color)
 
 .build-detail-footer
   background #fff
-  padding 5px
+  padding 5px 10px
   font-size 13px
   color $gray-darker
 

--- a/BlazarUI/app/stylus/components/build-detail.styl
+++ b/BlazarUI/app/stylus/components/build-detail.styl
@@ -44,15 +44,6 @@ build-status(color)
   p
     margin: 0
     font-size 13px
-
-.build-detail-body__commits-trigger
-  position absolute
-  color $link-color
-  left 0
-  top 5px
-  padding 0 10px
-  &:hover
-    cursor: pointer
       
 .build-detail-body__commit-desc
   height 30px
@@ -62,7 +53,7 @@ build-status(color)
   background inherit
   border none
   padding 0 10px
-  margin 0 0 0 20px
+  margin 0
   color $gray-darker
   font-size 12px
   line-height 2.5

--- a/BlazarUI/app/stylus/components/build-detail.styl
+++ b/BlazarUI/app/stylus/components/build-detail.styl
@@ -10,6 +10,7 @@ build-status(color)
     border-top 1px solid color
 
 .build-detail
+  position relative
   padding 0
   margin 0
   
@@ -22,6 +23,12 @@ build-status(color)
   &.alert-info
     build-status($info-dark)
       
+.build-detail-header
+  .cancel-build-button 
+    position absolute
+    top 4px
+    right 4px
+
 .build-detail-header__build-state
   font-weight $font-medium
   margin 0

--- a/BlazarUI/app/stylus/components/build-detail.styl
+++ b/BlazarUI/app/stylus/components/build-detail.styl
@@ -40,10 +40,20 @@ build-status(color)
   margin-left 5px
     
 .build-detail-body
+  position relative
   p
     margin: 0
     font-size 13px
 
+.build-detail-body__commits-trigger
+  position absolute
+  color $link-color
+  left 0
+  top 5px
+  padding 0 10px
+  &:hover
+    cursor: pointer
+      
 .build-detail-body__commit-desc
   height 30px
   overflow hidden
@@ -52,7 +62,7 @@ build-status(color)
   background inherit
   border none
   padding 0 10px
-  margin 0
+  margin 0 0 0 20px
   color $gray-darker
   font-size 12px
   line-height 2.5

--- a/BlazarUI/app/stylus/components/build-log-navigation.styl
+++ b/BlazarUI/app/stylus/components/build-log-navigation.styl
@@ -3,3 +3,7 @@
 .log-nav-btn
   display inline-block
   margin 10px 0 0 10px
+  
+  &.btn-default:active, &.btn-default:focus
+    background inherit
+    box-shadow none

--- a/BlazarUI/app/stylus/components/build-log-navigation.styl
+++ b/BlazarUI/app/stylus/components/build-log-navigation.styl
@@ -1,0 +1,5 @@
+@import '../variables'
+
+.log-nav-btn
+  display inline-block
+  margin 10px 0 0 10px

--- a/BlazarUI/app/stylus/components/build-log.styl
+++ b/BlazarUI/app/stylus/components/build-log.styl
@@ -2,7 +2,7 @@
 
 .build-log
   position absolute
-  top 220px
+  top 240px
   left 0
   bottom 0
   right 0

--- a/BlazarUI/app/stylus/components/build-log.styl
+++ b/BlazarUI/app/stylus/components/build-log.styl
@@ -25,3 +25,7 @@
   padding 1px 10px
   &:hover
     background #fff
+
+.log-line-end
+  margin-top 10px
+  font-weight $font-heavy

--- a/BlazarUI/app/stylus/components/build-log.styl
+++ b/BlazarUI/app/stylus/components/build-log.styl
@@ -1,15 +1,21 @@
 @import '../variables'
 
 .build-log
+  position absolute
+  top 220px
+  left 0
+  bottom 0
+  right 0
+  width 100%
+  overflow-y scroll
+  padding 10px 0
+  margin 0
   font-family $monospace
   font-size 12px  
   line-height 1.6
   word-wrap normal
   background $blue-gray
   border-radius 0
-  overflow-y auto
-  padding 10px 0
-  margin 0
   border none
 
 .log-line
@@ -19,8 +25,3 @@
   padding 1px 10px
   &:hover
     background #fff
-    
-.build-log-container
-  position relative
-  background $blue-gray
-  padding-bottom 5px

--- a/BlazarUI/app/stylus/helpers.styl
+++ b/BlazarUI/app/stylus/helpers.styl
@@ -38,3 +38,6 @@
       height 100%
       width 100%
       padding 8px
+
+.text-right
+  text-align right

--- a/BlazarUI/app/stylus/main.styl
+++ b/BlazarUI/app/stylus/main.styl
@@ -15,6 +15,7 @@
 @import 'components/build-detail'
 @import 'components/building-icon'
 @import 'components/build-log'
+@import 'components/build-log-navigation'
 @import 'components/branch-filter'
 @import 'components/collapsable'
 @import 'components/dashboard'

--- a/BlazarUI/app/stylus/page/build.styl
+++ b/BlazarUI/app/stylus/page/build.styl
@@ -1,3 +1,16 @@
+@import '../variables'
+
+.build-header
+  position fixed
+  top 45px
+  left $layout-offset-md
+  width "calc(100% - %s)" % $layout-offset-md
+  z-index 2
+  background #fff
+
+.build-body
+  margin-top 175px
+
 .log .log__line:nth-child(even)
   background rgba(0,0,0,0.025)
 
@@ -9,7 +22,6 @@ pre.log
   background-color #f5f5f5
   border none
   border-radius 0
-
 
 .log__line
   font-family Consolas, "Liberation Mono", Courier, monospace

--- a/BlazarUI/app/stylus/variables.styl
+++ b/BlazarUI/app/stylus/variables.styl
@@ -5,6 +5,7 @@ $font-thin = 100
 $font-light = 300
 $font-normal = 400
 $font-medium = 500
+$font-heavy = 600
 
 $color-text-standard = #333
 $color-text-light = #555

--- a/BlazarUI/app/stylus/vendor-overrides/bootstrap.styl
+++ b/BlazarUI/app/stylus/vendor-overrides/bootstrap.styl
@@ -11,6 +11,9 @@
 .btn
   border-radius $radius-standard
 
+  &:active, &:focus
+    outline 0
+    
 .pagination
   margin-bottom 15px
 

--- a/BlazarUI/appConfig.js
+++ b/BlazarUI/appConfig.js
@@ -4,6 +4,9 @@ const appConfig = {
   // sidebar polling frequency in ms
   buildsRefresh: process.env.GLOBAL_REFRESH || 5000,
   
+  // active build polling frequency in ms
+  activeBuildRefresh: process.env.ACTIVE_BUILD_REFRESH || 2500,
+
   // byte count when fetching log offsets
   offsetLength: process.env.BLAZAR_OFFSET_LENGTH || 50000,
 

--- a/BlazarUI/appConfig.js
+++ b/BlazarUI/appConfig.js
@@ -5,7 +5,7 @@ const appConfig = {
   buildsRefresh: process.env.GLOBAL_REFRESH || 5000,
   
   // byte count when fetching log offsets
-  offsetLength: process.env.BLAZAR_OFFSET_LENGTH || 90000,
+  offsetLength: process.env.BLAZAR_OFFSET_LENGTH || 50000,
 
   appRoot: process.env.BLAZAR_APP_URI || '',
   // If we have an env variable, gulp is proxying it through /api.

--- a/BlazarUI/appConfig.js
+++ b/BlazarUI/appConfig.js
@@ -2,7 +2,10 @@
 
 const appConfig = {
   // sidebar polling frequency in ms
-  buildsRefresh: 5000,
+  buildsRefresh: process.env.GLOBAL_REFRESH || 5000,
+  
+  // byte count when fetching log offsets
+  offsetLength: process.env.BLAZAR_OFFSET_LENGTH || 90000,
 
   appRoot: process.env.BLAZAR_APP_URI || '',
   // If we have an env variable, gulp is proxying it through /api.

--- a/BlazarUI/package.json
+++ b/BlazarUI/package.json
@@ -16,7 +16,6 @@
   "dependencies": {
     "ansi_up": "^1.2.1",
     "babel-core": "^4.7.0",
-    "babel-eslint": "^4.1.3",
     "babel-jest": "^4.0.0",
     "babel-loader": "^4.2.0",
     "binary-search": "^1.2.0",


### PR DESCRIPTION
Updates log processing. The build page currently loads the entire log, this change only loads what's necessary at a given time. 

 - loads the latest offset (log size - 50,000) on load
 - Uses infinite scroll to fetch next/previous offsets  
 - Updated to-top/top-bottom buttons to load the first/last offset.

There are a couple issues/bugs I'm still trying to iron out before this is ready to merge, notably piecing back together cutoff lines at the beginning/end of log depending on the direction being scrolled (as we need to assume when fetching data that the last line may be incomplete). Had this working fine with inactive builds - but in progress builds behave a bit differently. 