### PR TITLE
Reveal org dropdown

### DIFF
--- a/BlazarUI/app/stylus/components/build-log.styl
+++ b/BlazarUI/app/stylus/components/build-log.styl
@@ -2,7 +2,7 @@
 
 .build-log
   position absolute
-  z-index 2
+  z-index 1
   top 105px
   left 0
   bottom 0

--- a/BlazarUI/app/stylus/page/build.styl
+++ b/BlazarUI/app/stylus/page/build.styl
@@ -5,7 +5,7 @@
   top 45px
   left $layout-offset-md
   width "calc(100% - %s)" % $layout-offset-md
-  z-index 2
+  z-index 1
   background #fff
 
 .build-body


### PR DESCRIPTION
Increasing the z-index of the org dropdown has no effect, but lowering the z-indices of the build header and the build log solve the problem.

