### PR TITLE
Blink on previous build statuses

### DIFF
--- a/BlazarUI/app/scripts/components/shared/BuildingIcon.jsx
+++ b/BlazarUI/app/scripts/components/shared/BuildingIcon.jsx
@@ -3,11 +3,13 @@ import React, {Component, PropTypes} from 'react';
 class BuildingIcon extends Component {
 
   getClassNames() {
-    if (this.props.result === "IN_PROGRESS" && this.props.prevBuildState != '') {
-      return `building-icon sidebar__active-building-icon building-icon--${this.props.result}-laststatus-${this.props.prevBuildState} ${this.props.classNames} building-icon--${this.props.size}`;
+    let prevBuildStateModifier = ``;
+
+    if (this.props.result === "IN_PROGRESS" && this.props.prevBuildState) {
+      prevBuildStateModifier = `-laststatus-${this.props.prevBuildState}`;
     }
 
-    return `building-icon sidebar__active-building-icon building-icon--${this.props.result} ${this.props.classNames} building-icon--${this.props.size}`;
+    return `building-icon sidebar__active-building-icon building-icon--${this.props.result}${prevBuildStateModifier} ${this.props.classNames} building-icon--${this.props.size}`;
   }
 
   getInnerClassNames() {

--- a/BlazarUI/app/scripts/components/shared/BuildingIcon.jsx
+++ b/BlazarUI/app/scripts/components/shared/BuildingIcon.jsx
@@ -16,7 +16,7 @@ class BuildingIcon extends Component {
         'sidebar__active-building-icon',
         `building-icon--${this.props.size}`,
         `building-icon--${this.props.result}${prevBuildStateModifier}`,
-        `${this.props.classNames}`
+        this.props.classNames
       ]);
   }
 

--- a/BlazarUI/app/scripts/components/shared/BuildingIcon.jsx
+++ b/BlazarUI/app/scripts/components/shared/BuildingIcon.jsx
@@ -3,6 +3,10 @@ import React, {Component, PropTypes} from 'react';
 class BuildingIcon extends Component {
 
   getClassNames() {
+    if (this.props.result === "IN_PROGRESS" && this.props.prevBuildState != '') {
+      return `building-icon sidebar__active-building-icon building-icon--${this.props.result}-laststatus-${this.props.prevBuildState} ${this.props.classNames} building-icon--${this.props.size}`;
+    }
+
     return `building-icon sidebar__active-building-icon building-icon--${this.props.result} ${this.props.classNames} building-icon--${this.props.size}`;
   }
 

--- a/BlazarUI/app/scripts/components/shared/BuildingIcon.jsx
+++ b/BlazarUI/app/scripts/components/shared/BuildingIcon.jsx
@@ -1,19 +1,30 @@
 import React, {Component, PropTypes} from 'react';
+import classNames from 'classnames';
+import BuildStates from '../../constants/BuildStates'
 
 class BuildingIcon extends Component {
 
   getClassNames() {
     let prevBuildStateModifier = ``;
 
-    if (this.props.result === "IN_PROGRESS" && this.props.prevBuildState) {
+    if (this.props.result === BuildStates.IN_PROGRESS && this.props.prevBuildState) {
       prevBuildStateModifier = `-laststatus-${this.props.prevBuildState}`;
     }
 
-    return `building-icon sidebar__active-building-icon building-icon--${this.props.result}${prevBuildStateModifier} ${this.props.classNames} building-icon--${this.props.size}`;
+    return classNames([
+        'building-icon',
+        'sidebar__active-building-icon',
+        `building-icon--${this.props.size}`,
+        `building-icon--${this.props.result}${prevBuildStateModifier}`,
+        `${this.props.classNames}`
+      ]);
   }
 
   getInnerClassNames() {
-    return `building-icon-inner building-icon-inner--${this.props.size}`;
+    return classNames([
+      'building-icon-inner',
+      `building-icon-inner--${this.props.size}`
+    ]);
   }
 
   render() {

--- a/BlazarUI/app/scripts/components/sidebar/SidebarContainer.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarContainer.jsx
@@ -114,8 +114,6 @@ class SidebarContainer extends Component {
     const filteredBuilds = builds[this.state.toggleFilterState];
     const matches = getFilterMatches(filteredBuilds.toJS(), filterText);
 
-    //console.log(builds);
-
     return (
       <Sidebar>
         <div className="sidebar__filter">

--- a/BlazarUI/app/scripts/components/sidebar/SidebarContainer.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarContainer.jsx
@@ -114,6 +114,8 @@ class SidebarContainer extends Component {
     const filteredBuilds = builds[this.state.toggleFilterState];
     const matches = getFilterMatches(filteredBuilds.toJS(), filterText);
 
+    //console.log(builds);
+
     return (
       <Sidebar>
         <div className="sidebar__filter">

--- a/BlazarUI/app/scripts/components/sidebar/SidebarItem.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarItem.jsx
@@ -46,10 +46,10 @@ class SidebarItem extends Component {
   }
   
   renderBuildLink() {
-    const {buildType, build, hasBuild, prevBuildState} = this.props;
+    const {buildType, build, prevBuildState} = this.props;
     let icon, buildIdLink;
     
-    if (hasBuild) {
+    if (prevBuildState) {
       icon = (
         <Link to={build.blazarPath} className='sidebar-item__building-icon-link'>
           <BuildingIcon result={build.state} prevBuildState={prevBuildState} size='small' />

--- a/BlazarUI/app/scripts/components/sidebar/SidebarItem.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarItem.jsx
@@ -46,13 +46,13 @@ class SidebarItem extends Component {
   }
   
   renderBuildLink() {
-    const {buildType, build, hasBuild} = this.props;
+    const {buildType, build, hasBuild, prevBuildState} = this.props;
     let icon, buildIdLink;
     
     if (hasBuild) {
       icon = (
         <Link to={build.blazarPath} className='sidebar-item__building-icon-link'>
-          <BuildingIcon result={build.state} size='small' />
+          <BuildingIcon result={build.state} prevBuildState={prevBuildState} size='small' />
         </Link>
       );
 

--- a/BlazarUI/app/scripts/components/sidebar/SidebarRepoList.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarRepoList.jsx
@@ -28,6 +28,7 @@ class SidebarRepoList extends Component {
           key={build[buildType].id}
           hasBuild={buildType !== 'neverBuilt'}
           build={build[buildType]}
+          prevBuildState={buildType !== 'neverBuilt' ? build['lastBuild'].state : ''}
           buildType={buildType}
           gitInfo={build.gitInfo}
           isStarred={true}

--- a/BlazarUI/app/scripts/components/sidebar/SidebarRepoList.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarRepoList.jsx
@@ -26,9 +26,8 @@ class SidebarRepoList extends Component {
       return (
         <SidebarItem
           key={build[buildType].id}
-          hasBuild={buildType !== 'neverBuilt'}
           build={build[buildType]}
-          prevBuildState={buildType !== 'neverBuilt' ? build['lastBuild'].state : ''}
+          prevBuildState={buildType !== 'neverBuilt' ? build['lastBuild'].state : false}
           buildType={buildType}
           gitInfo={build.gitInfo}
           isStarred={true}

--- a/BlazarUI/app/stylus/components/building-icon.styl
+++ b/BlazarUI/app/stylus/components/building-icon.styl
@@ -3,6 +3,11 @@
 buildStatus(color)
   background-color color
   border 0 solid color
+  
+buildInProgressStatus(color)
+  buildStatus(color)
+  opacity 0
+  animation: blink 1.5s ease-in 0s infinite
 
 .building-icon
   display block
@@ -16,14 +21,19 @@ buildStatus(color)
   height 10px
 
 .building-icon--IN_PROGRESS
-  buildStatus($info)
-  opacity 0
-  animation: blink 1.5s ease-in 0s infinite
+  buildInProgressStatus($info)
+  
+.building-icon--IN_PROGRESS-laststatus-SUCCEEDED
+  buildInProgressStatus($success)
+  
+.building-icon--IN_PROGRESS-laststatus-CANCELLED
+  buildInProgressStatus($warning)
+  
+.building-icon--IN_PROGRESS-laststatus-FAILED
+  buildInProgressStatus($danger)
 
 .building-icon--LAUNCHING
-  buildStatus($default)
-  opacity 0
-  animation: blink 1.5s ease-in 0s infinite
+  buildInProgressStatus($default)
 
 .building-icon--CANCELLED
   buildStatus($warning)


### PR DESCRIPTION
Might be missing some intended behavior for first time builds - will need to load in another test project.

@benrlodge I left the css extra verbose in an attempt to follow the CSS naming pattern, but it seems like there is a better way to do it.