### PR TITLE
remove faulty assumptions on buildState

### DIFF
--- a/BlazarUI/app/scripts/components/sidebar/SidebarItem.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarItem.jsx
@@ -46,7 +46,7 @@ class SidebarItem extends Component {
   }
   
   renderBuildLink() {
-    const {buildType, build, prevBuildState} = this.props;
+    const {build, prevBuildState} = this.props;
     let icon, buildIdLink;
     
     if (prevBuildState) {

--- a/BlazarUI/app/scripts/components/sidebar/SidebarRepoList.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarRepoList.jsx
@@ -27,8 +27,7 @@ class SidebarRepoList extends Component {
         <SidebarItem
           key={build[buildType].id}
           build={build[buildType]}
-          prevBuildState={buildType !== 'neverBuilt' ? build['lastBuild'].state : false}
-          buildType={buildType}
+          prevBuildState={has(build, 'lastBuild') ? build['lastBuild'].state : false}
           gitInfo={build.gitInfo}
           isStarred={true}
         />


### PR DESCRIPTION
In the case where a build is being built for the first time, the build is in progress and there is no last build. This clears up some assumptions made on the value of `buildType`, and also no longer passes `buildType` to the `SidebarItem` component since it's not used.

cc @jonathanwgoodwin 