### PR TITLE
Don't link to repos, link to branches from repo text

### DIFF
--- a/BlazarUI/.blazar.yaml
+++ b/BlazarUI/.blazar.yaml
@@ -10,7 +10,12 @@ steps:
   - description: "Installing dependencies"
     commands:
       - npm install
-      - npm update bender-deps
+      - >
+        if [ -d ./node_modules/bender-deps ]; then
+          npm update bender-deps
+        else
+          npm install bender-deps
+        fi
   - description: "Linting"
     commands:
       - ./node_modules/.bin/gulp lint

--- a/BlazarUI/app/scripts/components/dashboard/StarredBranchesTableRow.jsx
+++ b/BlazarUI/app/scripts/components/dashboard/StarredBranchesTableRow.jsx
@@ -16,7 +16,7 @@ class StarredBranchesTableRow extends Component {
     const latestBuild = item.get('lastBuild');
     const latestBuildGitInfo = item.get('gitInfo');
 
-    const blazarRepositoryPath = latestBuildGitInfo.get('blazarRepositoryPath');
+    const blazarBranchPath = latestBuildGitInfo.get('blazarBranchPath');
     const repository = latestBuildGitInfo.get('repository');
     const branch = latestBuildGitInfo.get('branch');
 
@@ -25,7 +25,7 @@ class StarredBranchesTableRow extends Component {
         <tr>
           <td />
           <td>
-            <Link to={blazarRepositoryPath}>{repository}</Link>
+            <Link to={blazarBranchPath}>{repository}</Link>
           </td>
           <td>
             {branch}
@@ -65,7 +65,7 @@ class StarredBranchesTableRow extends Component {
           {buildResultIcon(latestBuild.get('state'))}
         </td>
         <td>
-          <Link to={blazarRepositoryPath}>{repository}</Link>
+          <Link to={blazarBranchPath}>{repository}</Link>
         </td>
         <td> 
           {branch}

--- a/BlazarUI/app/scripts/components/dashboard/StarredBranchesTableRow.jsx
+++ b/BlazarUI/app/scripts/components/dashboard/StarredBranchesTableRow.jsx
@@ -18,7 +18,6 @@ class StarredBranchesTableRow extends Component {
 
     const blazarRepositoryPath = latestBuildGitInfo.get('blazarRepositoryPath');
     const repository = latestBuildGitInfo.get('repository');
-    const blazarBranchPath = latestBuildGitInfo.get('blazarBranchPath');
     const branch = latestBuildGitInfo.get('branch');
 
     if (latestBuild === undefined) {
@@ -29,7 +28,7 @@ class StarredBranchesTableRow extends Component {
             <Link to={blazarRepositoryPath}>{repository}</Link>
           </td>
           <td>
-            <Link to={blazarBranchPath}>{branch}</Link>
+            {branch}
           </td>
           <td> No build history </td>
           <td />
@@ -69,7 +68,7 @@ class StarredBranchesTableRow extends Component {
           <Link to={blazarRepositoryPath}>{repository}</Link>
         </td>
         <td> 
-          <Link to={blazarBranchPath}>{branch}</Link>
+          {branch}
         </td>
         <td>
           <Link to={latestBuild.get('blazarPath')}>{latestBuild.get('buildNumber')}</Link>

--- a/BlazarUI/app/scripts/components/sidebar/SidebarItem.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarItem.jsx
@@ -23,24 +23,22 @@ class SidebarItem extends Component {
     return (
       <div className='sidebar-item__repo-link'>
         <Icon type='octicon' name='repo' classNames='icon-muted'/>{ ' ' }
-        <Link to={gitInfo.blazarRepositoryPath} className='sidebar-item__module-branch-name'>
+        <Link to={gitInfo.blazarBranchPath} className='sidebar-item__module-branch-name'>
           {truncate(gitInfo.repository, 30, true)}
         </Link>
       </div>
     );
   }
 
-  renderBranchLink() {
+  renderBranchText() {
     const {gitInfo} = this.props;
 
     return (
       <div className='sidebar-item__branch-link'>
         <Icon type='octicon' name='git-branch' classNames='icon-muted'/>{ ' ' }
-        <Link 
-          to={gitInfo.blazarBranchPath}
-          className='sidebar-item__module-branch-name'>
-            {truncate(gitInfo.branch, 40, true)}
-        </Link>
+        <span className='sidebar-item__module-branch-name'>
+          {truncate(gitInfo.branch, 40, true)}
+        </span>
       </div>
     )
   }
@@ -87,7 +85,7 @@ class SidebarItem extends Component {
       <li className={this.getItemClasses()}>
         {this.renderBuildLink()}
         {this.renderRepoLink()}
-        {this.renderBranchLink()}
+        {this.renderBranchText()}
       </li>
     )
   }


### PR DESCRIPTION
1. In the sidebar, repo text now links to repo-branch, branch text is no longer a link:

![screen shot 2016-02-04 at 10 58 21 am](https://cloud.githubusercontent.com/assets/2453653/12820697/40d69cd4-cb2e-11e5-9b9c-00fb997b3955.png)

2. On the starred branch dashboard, same idea:

![screen shot 2016-02-04 at 10 58 31 am](https://cloud.githubusercontent.com/assets/2453653/12820805/a56c5b5c-cb2e-11e5-92a6-abd368803426.png)

/cc @jhaber 