### PR TITLE
refresh breadcrumb paths

### DIFF
--- a/BlazarUI/app/scripts/components/header/Breadcrumb.jsx
+++ b/BlazarUI/app/scripts/components/header/Breadcrumb.jsx
@@ -8,10 +8,12 @@ class Breadcrumb extends Component {
 
   constructor(props) {
     super(props);
-    
+  }
+
+  refreshPaths() {
     const {appRoot, params} = this.props;
     const root = `${appRoot}/builds`;
-    
+
     this.paths = {
       host: `${root}/${params.host}`,
       org: `${root}/${params.host}/${params.org}`,
@@ -23,6 +25,8 @@ class Breadcrumb extends Component {
   }
 
   render() {
+    this.refreshPaths();
+
     if (this.props.isActive || this.props.dontLink) {
       const classes = ClassNames([
         'crumb',


### PR DESCRIPTION
Constructor is only called once, render is called every time we update the props - so the paths are only set at the initial page load if the breadcrumbs don't disappear while navigating the app. This fixes that issue