### PR TITLE
Alphabetize sidebar repo list

### DIFF
--- a/BlazarUI/app/scripts/components/Helpers.js
+++ b/BlazarUI/app/scripts/components/Helpers.js
@@ -203,3 +203,30 @@ export const getPreviousBuildState = function(builds) {
   return completedBuilds.get(0).get('state');
 };
 
+export const sortBuildsByRepoAndBranch = function(builds) {
+  return builds.sort((a, b) => {
+    let repoNameA = a.gitInfo.repository.toLowerCase();
+    let repoNameB = b.gitInfo.repository.toLowerCase();
+
+    if (repoNameA < repoNameB) {
+      return -1;
+    }
+
+    else if (repoNameA > repoNameB) {
+      return 1;
+    }
+
+    let branchNameA = a.gitInfo.branch.toLowerCase();
+    let branchNameB = b.gitInfo.branch.toLowerCase();
+
+    if (branchNameA < branchNameB) {
+      return -1;
+    }
+
+    else if (branchNameA > branchNameB) {
+      return 1;
+    }
+
+    return 0;
+  });
+};

--- a/BlazarUI/app/scripts/components/Helpers.js
+++ b/BlazarUI/app/scripts/components/Helpers.js
@@ -205,6 +205,8 @@ export const getPreviousBuildState = function(builds) {
 
 export const sortBuildsByRepoAndBranch = function(builds) {
   return builds.sort((a, b) => {
+
+    // Sort by repo, DESC
     let repoNameA = a.gitInfo.repository.toLowerCase();
     let repoNameB = b.gitInfo.repository.toLowerCase();
 
@@ -216,17 +218,18 @@ export const sortBuildsByRepoAndBranch = function(builds) {
       return 1;
     }
 
+    // Sort by branch, master at top
     let branchNameA = a.gitInfo.branch.toLowerCase();
     let branchNameB = b.gitInfo.branch.toLowerCase();
 
-    if (branchNameA < branchNameB) {
-      return -1;
+    let branchAIsMaster = branchNameA === 'master';
+    let branchBIsMaster = branchNameB === 'master';
+
+    if (branchAIsMaster || branchBIsMaster) {
+      return (branchBIsMaster ? 1 : 0) - (branchAIsMaster ? 1 : 0);
     }
 
-    else if (branchNameA > branchNameB) {
-      return 1;
-    }
-
-    return 0;
+    // Sort by branch, DESC
+    return branchNameA.localeCompare(branchNameB);
   });
 };

--- a/BlazarUI/app/scripts/components/sidebar/SidebarRepoList.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarRepoList.jsx
@@ -3,7 +3,7 @@ import {bindAll} from 'underscore';
 import LazyRender from '../shared/LazyRender.jsx';
 import Loader from '../shared/Loader.jsx';
 import SidebarItem from './SidebarItem.jsx';
-import {has, sortBy} from 'underscore';
+import {has} from 'underscore';
 import {sortBuildsByRepoAndBranch} from '../Helpers.js';
 
 class SidebarRepoList extends Component {

--- a/BlazarUI/app/scripts/components/sidebar/SidebarRepoList.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarRepoList.jsx
@@ -3,7 +3,8 @@ import {bindAll} from 'underscore';
 import LazyRender from '../shared/LazyRender.jsx';
 import Loader from '../shared/Loader.jsx';
 import SidebarItem from './SidebarItem.jsx';
-import {has} from 'underscore';
+import {has, sortBy} from 'underscore';
+import {sortBuildsByRepoAndBranch} from '../Helpers.js';
 
 class SidebarRepoList extends Component {
 
@@ -20,7 +21,7 @@ class SidebarRepoList extends Component {
       );
     }
 
-    const buildsList = filteredBuilds.map( (build) => {
+    const buildsList = sortBuildsByRepoAndBranch(filteredBuilds).map( (build) => {
       const buildType = has(build, 'inProgressBuild') ? 'inProgressBuild' : has(build, 'lastBuild') ? 'lastBuild' : 'neverBuilt'
 
       return (


### PR DESCRIPTION
Alphabetize by:

1) Repo name, desc
2) Branch name, `master` first
3) Branch name, desc

also ignoring case

cc @benrlodge you might know if there's a better way to perform these comparisons

![screen shot 2016-02-11 at 4 33 44 pm](https://cloud.githubusercontent.com/assets/2453653/12991443/422fa396-d0dd-11e5-8e3a-0adde4d6637d.png)
