### PR TITLE
show a default icon for first time builds

### DIFF
--- a/BlazarUI/app/scripts/components/sidebar/SidebarItem.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarItem.jsx
@@ -66,7 +66,7 @@ class SidebarItem extends Component {
     else {
       icon = (
         <div className='sidebar-item__building-icon-link'>
-          <BuildingIcon result='never-built' size='small' />
+          {buildResultIcon(build.state, 'never-built')}
         </div>
       );
     }

--- a/BlazarUI/app/stylus/components/building-icon.styl
+++ b/BlazarUI/app/stylus/components/building-icon.styl
@@ -31,6 +31,9 @@ buildInProgressStatus(color)
 .building-icon--IN_PROGRESS-laststatus-SKIPPED
   buildInProgressStatus($skipped)
 
+.building-icon--IN_PROGRESS-laststatus-never-built
+  buildInProgressStatus($default)
+
 .building-icon--IN_PROGRESS, .building-icon--QUEUED, .building-icon--LAUNCHING
   buildStatus($info)
 


### PR DESCRIPTION
We can add a symbol if we think it'll make things more clear. Before, however, no icon would appear.

![screen shot 2016-02-16 at 1 15 40 pm](https://cloud.githubusercontent.com/assets/2453653/13086061/6a1ed5a4-d4af-11e5-9a4c-b5ac66253ad3.png)
