### PR TITLE
two bugs with the log

### DIFF
--- a/BlazarUI/app/scripts/data/BuildApi.js
+++ b/BlazarUI/app/scripts/data/BuildApi.js
@@ -160,8 +160,11 @@ class BuildApi {
   
     if (this.build.logCollection.shouldPoll && this.build.model.data.state === BuildStates.IN_PROGRESS) {
       this._fetchLog().done((data, textStatus, jqxhr) => {
-        this._triggerUpdate();
-        this.build.logCollection.requestOffset = data.nextOffset;
+
+        if (data.nextOffset !== -1) {
+          this._triggerUpdate();
+          this.build.logCollection.requestOffset = data.nextOffset;
+        }
         
         setTimeout(() => {
           this._pollLog();
@@ -345,8 +348,8 @@ class BuildApi {
       return;
     }
 
-    logSizePromise.done((size) => {
-      this.build.logCollection.options.size = size;
+    logSizePromise.done((resp) => {
+      this.build.logCollection.options.size = resp.size;
     });
       
     return logSizePromise;


### PR DESCRIPTION
1) If we poll too fast, we get a `nextOffset` of `-1` - so wait a bit, retry until we get a real offset (this fixes the last few lines not appearing issue)

2) Misleading name variable after some presumed API changes led to the `To Bottom` button breaking. Fixed now

cc @jonathanwgoodwin @jhaber no more log problems? :)