### PR TITLE
Debug query param for singularity task link

### DIFF
--- a/BlazarUI/app/scripts/components/repo-build/RepoBuildModulesTable.jsx
+++ b/BlazarUI/app/scripts/components/repo-build/RepoBuildModulesTable.jsx
@@ -19,7 +19,7 @@ class RepoBuildModulesTable extends Component {
 
     return this.props.buildTable({
       data: this.props.data,
-      columnNames: ['', 'Module Build', 'Start Time', 'Duration', 'Singularity Task', ''],
+      columnNames: ['', 'Module Build', 'Start Time', 'Duration', ''],
       rowComponent: RepoBuildModulesTableRow,
       showProgress: true,
       params: this.props.params

--- a/BlazarUI/app/scripts/components/repo-build/RepoBuildModulesTableRow.jsx
+++ b/BlazarUI/app/scripts/components/repo-build/RepoBuildModulesTableRow.jsx
@@ -21,7 +21,15 @@ class RepoBuildModulesTableRow extends Component {
     );    
   }
 
+  isDebugMode() {
+    return window.location.href.indexOf('?debug') > -1;
+  }
+
   renderSingularityLink() {
+    if (!this.isDebugMode()) {
+      return null;
+    }
+
     const {taskId} = this.props.data;
 
     if (!taskId) {
@@ -34,7 +42,9 @@ class RepoBuildModulesTableRow extends Component {
     const singularityPath = `https://tools.hubteamqa.com/singularity/task/${taskId}`;
 
     return (
-      <a href={singularityPath} target="_blank">{truncate(taskId, 30, true)}</a>  
+      <td>
+        <a href={singularityPath} target="_blank">{truncate(taskId, 30, true)}</a>
+      </td>
     );
   }
 
@@ -81,9 +91,7 @@ class RepoBuildModulesTableRow extends Component {
         <td>
           {this.renderDuration()}
         </td>
-        <td>
-          {this.renderSingularityLink()}
-        </td>
+        {this.renderSingularityLink()}
         <td>
         </td>
       </tr>


### PR DESCRIPTION
Now, default behavior on a repo build page is to _not_ show the singularity task. If you add `?debug` to the end of the url, then the task link will appear. cc @jonathanwgoodwin 

(this is very much temporary)