### PR TITLE
running timer on branch build history page

### DIFF
--- a/BlazarUI/app/scripts/components/branch/BranchBuildHistoryTableRow.jsx
+++ b/BlazarUI/app/scripts/components/branch/BranchBuildHistoryTableRow.jsx
@@ -10,8 +10,27 @@ import {tableRowBuildState, timestampFormatted, humanizeText, buildResultIcon, g
 import Icon from '../shared/Icon.jsx';
 import Sha from '../shared/Sha.jsx';
 
+let initialState = {
+  moment: moment()
+}
 
 class BranchBuildHistoryTableRow extends Component {
+
+  constructor(props) {
+    super(props);
+
+    this.state = initialState;
+  }
+
+  componentDidMount() {
+    this.interval = setInterval(this.updateMoment.bind(this), 1000);
+  }
+
+  updateMoment() {
+    this.setState({
+      moment: moment()
+    })
+  }
 
   onTableClick(e) {
     if (e.target.className === 'sha-link') {
@@ -49,7 +68,7 @@ class BranchBuildHistoryTableRow extends Component {
     let duration = data.duration;
 
     if (data.state === BuildStates.IN_PROGRESS) {
-      duration = timestampDuration(data.startTimestamp, moment());
+      duration = timestampDuration(data.startTimestamp, this.state.moment);
     }
 
     return getTableDurationText(data.state, duration);

--- a/BlazarUI/app/scripts/components/branch/BranchBuildHistoryTableRow.jsx
+++ b/BlazarUI/app/scripts/components/branch/BranchBuildHistoryTableRow.jsx
@@ -74,10 +74,6 @@ class BranchBuildHistoryTableRow extends Component {
   render() {
     const {data, params} = this.props;
 
-    setTimeout(() => {
-      this.forceUpdate();
-    }, 1000);
-
     return (
       <Link onClick={this.onTableClick.bind(this)} to={data.blazarPath}>
         <tr className={this.getRowClassNames(data.state)}>

--- a/BlazarUI/app/scripts/components/branch/BranchBuildHistoryTableRow.jsx
+++ b/BlazarUI/app/scripts/components/branch/BranchBuildHistoryTableRow.jsx
@@ -3,8 +3,9 @@ import BuildStates from '../../constants/BuildStates.js';
 import { Link } from 'react-router';
 import {LABELS, iconStatus} from '../constants';
 import classNames from 'classnames';
+import moment from 'moment';
 
-import {tableRowBuildState, timestampFormatted, humanizeText, buildResultIcon, getTableDurationText, buildIsOnDeck} from '../Helpers';
+import {tableRowBuildState, timestampFormatted, humanizeText, buildResultIcon, getTableDurationText, buildIsOnDeck, timestampDuration} from '../Helpers';
 
 import Icon from '../shared/Icon.jsx';
 import Sha from '../shared/Sha.jsx';
@@ -45,8 +46,13 @@ class BranchBuildHistoryTableRow extends Component {
   
   renderDuration() {
     const {data} = this.props;
+    let duration = data.duration;
 
-    return getTableDurationText(data.state, data.duration);
+    if (data.state === BuildStates.IN_PROGRESS) {
+      duration = timestampDuration(data.startTimestamp, moment());
+    }
+
+    return getTableDurationText(data.state, duration);
   }
   
   renderStartTime() {
@@ -67,6 +73,10 @@ class BranchBuildHistoryTableRow extends Component {
 
   render() {
     const {data, params} = this.props;
+
+    setTimeout(() => {
+      this.forceUpdate();
+    }, 1000);
 
     return (
       <Link onClick={this.onTableClick.bind(this)} to={data.blazarPath}>

--- a/BlazarUI/app/scripts/components/branch/BranchContainer.jsx
+++ b/BlazarUI/app/scripts/components/branch/BranchContainer.jsx
@@ -31,8 +31,7 @@ let initialState = {
   showModuleModal: false,
   modules: Immutable.List.of(),
   selectedModules: [],
-  buildDownstreamModules: 'WITHIN_REPOSITORY',
-  moment: moment()
+  buildDownstreamModules: 'WITHIN_REPOSITORY'
 };
 
 class BranchContainer extends Component {
@@ -45,18 +44,6 @@ class BranchContainer extends Component {
 
   componentDidMount() {
     this.setup(this.props.params);
-
-    this.updateMoment();
-  }
-
-  updateMoment() {
-    this.setState({
-      moment: moment()
-    });
-
-    setTimeout(() => {
-      this.updateMoment();
-    })
   }
 
   componentWillReceiveProps(nextprops) {

--- a/BlazarUI/app/scripts/components/branch/BranchContainer.jsx
+++ b/BlazarUI/app/scripts/components/branch/BranchContainer.jsx
@@ -12,6 +12,7 @@ import GenericErrorMessage from '../shared/GenericErrorMessage.jsx';
 import BuildButton from './BuildButton.jsx';
 import ModuleModal from '../shared/ModuleModal.jsx';
 import Immutable from 'immutable';
+import moment from 'moment';
 
 import StarStore from '../../stores/starStore';
 import StarActions from '../../actions/starActions';
@@ -30,7 +31,8 @@ let initialState = {
   showModuleModal: false,
   modules: Immutable.List.of(),
   selectedModules: [],
-  buildDownstreamModules: 'WITHIN_REPOSITORY'
+  buildDownstreamModules: 'WITHIN_REPOSITORY',
+  moment: moment()
 };
 
 class BranchContainer extends Component {
@@ -43,6 +45,18 @@ class BranchContainer extends Component {
 
   componentDidMount() {
     this.setup(this.props.params);
+
+    this.updateMoment();
+  }
+
+  updateMoment() {
+    this.setState({
+      moment: moment()
+    });
+
+    setTimeout(() => {
+      this.updateMoment();
+    })
   }
 
   componentWillReceiveProps(nextprops) {
@@ -119,6 +133,7 @@ class BranchContainer extends Component {
         <BranchBuildHistoryTable
           data={this.state.builds}
           loading={this.state.loadingBranches}
+          currentTimestamp={this.state.moment}
           {...this.state}
           {...this.props}
         />

--- a/BlazarUI/app/scripts/components/branch/BranchContainer.jsx
+++ b/BlazarUI/app/scripts/components/branch/BranchContainer.jsx
@@ -12,7 +12,6 @@ import GenericErrorMessage from '../shared/GenericErrorMessage.jsx';
 import BuildButton from './BuildButton.jsx';
 import ModuleModal from '../shared/ModuleModal.jsx';
 import Immutable from 'immutable';
-import moment from 'moment';
 
 import StarStore from '../../stores/starStore';
 import StarActions from '../../actions/starActions';
@@ -120,7 +119,6 @@ class BranchContainer extends Component {
         <BranchBuildHistoryTable
           data={this.state.builds}
           loading={this.state.loadingBranches}
-          currentTimestamp={this.state.moment}
           {...this.state}
           {...this.props}
         />


### PR DESCRIPTION
Any idea on how to do this better? Running timer for in progress builds. There's not much of a state to update higher up in the hierarchy, since the only thing changing is the result of `moment()`. /cc @benrlodge 