### PR TITLE
go back to old in progress icons

### DIFF
--- a/BlazarUI/app/scripts/components/Helpers.js
+++ b/BlazarUI/app/scripts/components/Helpers.js
@@ -159,9 +159,8 @@ export const getPathname = function() {
 
 // To do: move these out as components in components/shared
 export const buildResultIcon = function(result, prevBuildState='') {
-  const classNames = getBuildStatusIconClassNames(result, prevBuildState);
-  const resultForIconSymbol = result != BuildStates.IN_PROGRESS ? result : prevBuildState != '' ? prevBuildState : BuildStates.IN_PROGRESS;
-  const iconNames = Immutable.List.of(iconStatus[resultForIconSymbol]);
+  const classNames = getBuildStatusIconClassNames(result);
+  const iconNames = Immutable.List.of(iconStatus[result]);
 
   return (
     <div className="table-icon-container">
@@ -174,16 +173,10 @@ export const buildResultIcon = function(result, prevBuildState='') {
   );
 };
 
-export const getBuildStatusIconClassNames = function(result, prevBuildState) {
-  let prevBuildStateModifier = ``;
-
-  if (result === BuildStates.IN_PROGRESS && prevBuildState) {
-    prevBuildStateModifier = `-laststatus-${prevBuildState}`;
-  }
-
+export const getBuildStatusIconClassNames = function(result) {
   return classNames([
     'building-icon',
-    `building-icon--${result}${prevBuildStateModifier}`
+    `building-icon--${result}`
   ]);
 };
 

--- a/BlazarUI/app/stylus/components/building-icon.styl
+++ b/BlazarUI/app/stylus/components/building-icon.styl
@@ -2,11 +2,6 @@
 
 buildStatus(color)
   color color
-  
-buildInProgressStatus(color)
-  buildStatus(color)
-  opacity 0
-  animation: blink 1.5s ease-in 0s infinite
 
 .building-icon
   display block
@@ -18,21 +13,6 @@ buildInProgressStatus(color)
 .building-icon-inner--small
   width 10px
   height 10px
-
-.building-icon--IN_PROGRESS-laststatus-SUCCEEDED
-  buildInProgressStatus($success)
-  
-.building-icon--IN_PROGRESS-laststatus-CANCELLED
-  buildInProgressStatus($warning)
-  
-.building-icon--IN_PROGRESS-laststatus-FAILED, .building-icon--IN_PROGRESS-laststatus-UNSTABLE
-  buildInProgressStatus($danger)
-  
-.building-icon--IN_PROGRESS-laststatus-SKIPPED
-  buildInProgressStatus($skipped)
-
-.building-icon--IN_PROGRESS-laststatus-never-built
-  buildInProgressStatus($default)
 
 .building-icon--IN_PROGRESS, .building-icon--QUEUED, .building-icon--LAUNCHING, .building-icon--WAITING_FOR_UPSTREAM_BUILD, .building-icon--WAITING_FOR_BUILD_SLOT
   buildStatus($info)


### PR DESCRIPTION
With the icon rework, consistency in icons across sidebar/table led to inconsistency and confusion with the different in progress icons (we shouldn't display past status on modules). so we're going back to the old in progress icons.