### PR TITLE
Improve tables

### DIFF
--- a/BlazarUI/app/scripts/components/branch/BranchBuildHistoryTableRow.jsx
+++ b/BlazarUI/app/scripts/components/branch/BranchBuildHistoryTableRow.jsx
@@ -48,7 +48,7 @@ class BranchBuildHistoryTableRow extends Component {
   getRowClassNames(state) {
     return classNames([
       tableRowBuildState(state),
-      'branch-build-history-row'
+      'clickable-table-row'
     ]);
   }
 
@@ -123,7 +123,7 @@ class BranchBuildHistoryTableRow extends Component {
 
 BranchBuildHistoryTableRow.contextTypes = {
   router: PropTypes.object.isRequired
-}
+};
 
 BranchBuildHistoryTableRow.propTypes = {
   data: PropTypes.object.isRequired

--- a/BlazarUI/app/scripts/components/dashboard/StarredBranchesTableRow.jsx
+++ b/BlazarUI/app/scripts/components/dashboard/StarredBranchesTableRow.jsx
@@ -51,23 +51,12 @@ class StarredBranchesTableRow extends Component {
       sha = <Sha gitInfo={gitInfo} build={latestBuild} />;
     }
 
-    let currentState;
-    let previousState;
-
-    if (item.get('inProgressBuild') !== undefined) {
-      currentState = item.get('inProgressBuild').get('state');
-      previousState = latestBuild.get('state');
-    }
-
-    else {
-      currentState = latestBuild.get('state');
-      previousState = '';
-    }
+    let buildToUse = item.get('inProgressBuild') !== undefined ? item.get('inProgressBuild') : latestBuild;
 
     return (
-      <tr className={tableRowBuildState(latestBuild.state)}>
+      <tr className={tableRowBuildState(buildToUse.get('state'))}>
         <td className='build-status'>
-          {buildResultIcon(currentState, previousState)}
+          {buildResultIcon(buildToUse.get('state'))}
         </td>
         <td>
           <Link to={blazarBranchPath}>{repository}</Link>
@@ -76,10 +65,10 @@ class StarredBranchesTableRow extends Component {
           {branch}
         </td>
         <td>
-          <Link to={latestBuild.get('blazarPath')}>{latestBuild.get('buildNumber')}</Link>
+          <Link to={buildToUse.get('blazarPath')}>{buildToUse.get('buildNumber')}</Link>
         </td>
         <td>
-          {timestampFormatted(latestBuild.get('startTimestamp'))}
+          {timestampFormatted(buildToUse.get('startTimestamp'))}
         </td>
         <td>
           {sha}

--- a/BlazarUI/app/scripts/components/dashboard/StarredBranchesTableRow.jsx
+++ b/BlazarUI/app/scripts/components/dashboard/StarredBranchesTableRow.jsx
@@ -2,6 +2,7 @@ import React, {Component, PropTypes} from 'react';
 const Link = require('react-router').Link;
 import {has} from 'underscore';
 import {buildResultIcon, tableRowBuildState, timestampFormatted} from '../Helpers';
+import classNames from 'classnames';
 
 import Icon from '../shared/Icon.jsx';
 import Sha from '../shared/Sha.jsx';
@@ -9,6 +10,30 @@ import CommitMessage from '../shared/CommitMessage.jsx';
 
 class StarredBranchesTableRow extends Component {
 
+  constructor(props, context) {
+    super(props, context);
+  }
+
+  getRowClassNames(state) {
+    return classNames([
+      tableRowBuildState(state),
+      'clickable-table-row'
+    ]);
+  }
+
+  onTableClick(blazarBranchPath, blazarPath, e) {
+    if (e.target.className === 'sha-link') {
+      window.open(e.target.href, '_blank');
+    }
+
+    else if (e.target.className === 'build-number') {
+      this.context.router.push(blazarPath);
+    }
+
+    else {
+      this.context.router.push(blazarBranchPath);
+    }
+  }
 
   render() {
 
@@ -54,7 +79,7 @@ class StarredBranchesTableRow extends Component {
     let buildToUse = item.get('inProgressBuild') !== undefined ? item.get('inProgressBuild') : latestBuild;
 
     return (
-      <tr className={tableRowBuildState(buildToUse.get('state'))}>
+      <tr onClick={this.onTableClick.bind(this, blazarBranchPath, buildToUse.get('blazarPath'))} className={this.getRowClassNames(buildToUse.get('state'))}>
         <td className='build-status'>
           {buildResultIcon(buildToUse.get('state'))}
         </td>
@@ -65,7 +90,7 @@ class StarredBranchesTableRow extends Component {
           {branch}
         </td>
         <td>
-          <Link to={buildToUse.get('blazarPath')}>{buildToUse.get('buildNumber')}</Link>
+          <Link className='build-number' to={buildToUse.get('blazarPath')}>{buildToUse.get('buildNumber')}</Link>
         </td>
         <td>
           {timestampFormatted(buildToUse.get('startTimestamp'))}
@@ -79,6 +104,10 @@ class StarredBranchesTableRow extends Component {
   }
   
 }
+
+StarredBranchesTableRow.contextTypes = {
+  router: PropTypes.object.isRequired
+};
 
 StarredBranchesTableRow.propTypes = {
   item: PropTypes.object,

--- a/BlazarUI/app/scripts/components/dashboard/StarredBranchesTableRow.jsx
+++ b/BlazarUI/app/scripts/components/dashboard/StarredBranchesTableRow.jsx
@@ -26,12 +26,12 @@ class StarredBranchesTableRow extends Component {
       window.open(e.target.href, '_blank');
     }
 
-    else if (e.target.className === 'build-number') {
-      this.context.router.push(blazarPath);
+    else if (e.target.className === 'repo-link') {
+      this.context.router.push(blazarBranchPath);
     }
 
     else {
-      this.context.router.push(blazarBranchPath);
+      this.context.router.push(blazarPath);
     }
   }
 
@@ -84,13 +84,13 @@ class StarredBranchesTableRow extends Component {
           {buildResultIcon(buildToUse.get('state'))}
         </td>
         <td>
-          <Link to={blazarBranchPath}>{repository}</Link>
+          <Link className='repo-link' to={blazarBranchPath}>{repository}</Link>
         </td>
         <td> 
           {branch}
         </td>
         <td>
-          <Link className='build-number' to={buildToUse.get('blazarPath')}>{buildToUse.get('buildNumber')}</Link>
+          <Link to={buildToUse.get('blazarPath')}>{buildToUse.get('buildNumber')}</Link>
         </td>
         <td>
           {timestampFormatted(buildToUse.get('startTimestamp'))}

--- a/BlazarUI/app/scripts/components/org/OrgTableRow.jsx
+++ b/BlazarUI/app/scripts/components/org/OrgTableRow.jsx
@@ -1,11 +1,37 @@
 import React, {Component, PropTypes} from 'react';
 import { Link } from 'react-router';
+import classNames from 'classnames';
 
 import BuildStates from '../../constants/BuildStates.js';
 import {tableRowBuildState, humanizeText, timestampFormatted, buildResultIcon} from '../Helpers';
 import Sha from '../shared/Sha.jsx';
 
 class OrgTableRow extends Component {
+
+  constructor(props, context) {
+    super(props, context);
+  }
+
+  getRowClassNames(state) {
+    return classNames([
+      tableRowBuildState(state),
+      'clickable-table-row'
+    ]);
+  }
+
+  onTableClick(blazarRepositoryPath, blazarPath, e) {
+    if (e.target.className === 'sha-link') {
+      window.open(e.target.href, '_blank');
+    }
+
+    else if (e.target.className === 'repo-link') {
+      this.context.router.push(blazarRepositoryPath);
+    }
+
+    else if (blazarPath !== undefined) {
+      this.context.router.push(blazarPath);
+    }
+  }
 
   render() {
 
@@ -27,12 +53,12 @@ class OrgTableRow extends Component {
     }
 
     return (
-      <tr className={tableRowBuildState(build.state)}>
+      <tr onClick={this.onTableClick.bind(this, this.props.data.get('blazarRepositoryPath'), build.blazarPath)} className={this.getRowClassNames(build.state)}>
         <td className='build-status'>
           {buildResultIcon(build.state)}
         </td>
         <td>
-          <Link to={this.props.data.get('blazarRepositoryPath')}>
+          <Link className='repo-link' to={this.props.data.get('blazarRepositoryPath')}>
             {this.props.data.get('repository')}
           </Link>
         </td>
@@ -53,6 +79,10 @@ class OrgTableRow extends Component {
   }
 
 }
+
+OrgTableRow.contextTypes = {
+  router: PropTypes.object.isRequired
+};
 
 OrgTableRow.propTypes = {
   data: PropTypes.object.isRequired

--- a/BlazarUI/app/scripts/components/repo-build/RepoBuildModulesTableRow.jsx
+++ b/BlazarUI/app/scripts/components/repo-build/RepoBuildModulesTableRow.jsx
@@ -4,10 +4,37 @@ import BuildStates from '../../constants/BuildStates.js';
 import ProgressBar from 'react-bootstrap/lib/ProgressBar';
 import {contains, has} from 'underscore';
 import moment from 'moment';
+import classNames from 'classnames';
 import {humanizeText, timestampFormatted, timestampDuration, tableRowBuildState, truncate, buildResultIcon, getTableDurationText} from '../Helpers';
 
 class RepoBuildModulesTableRow extends Component {
-  
+
+  constructor(props, context) {
+    super(props, context);
+  }
+
+  isDebugMode() {
+    return window.location.href.indexOf('?debug') > -1;
+  }
+
+  getRowClassNames(state) {
+    return classNames([
+      tableRowBuildState(state),
+      'clickable-table-row'
+    ]);
+  }
+
+  onTableClick(e) {
+    const {data} = this.props;
+
+    if (e.target.className === 'singularity-link') {
+      window.open(e.target.href, '_blank');
+      return false;
+    }
+
+    this.context.router.push(data.blazarPath);
+  }
+
   renderBuildLink() {
     const {data, params} = this.props;
 
@@ -20,10 +47,6 @@ class RepoBuildModulesTableRow extends Component {
     return (
       <span><Link to={data.blazarPath}>{data.name}</Link></span>
     );    
-  }
-
-  isDebugMode() {
-    return window.location.href.indexOf('?debug') > -1;
   }
 
   renderSingularityLink() {
@@ -44,7 +67,7 @@ class RepoBuildModulesTableRow extends Component {
 
     return (
       <td>
-        <a href={singularityPath} target="_blank">{truncate(taskId, 30, true)}</a>
+        <a className='singularity-link' href={singularityPath} target="_blank">{truncate(taskId, 30, true)}</a>
       </td>
     );
   }
@@ -62,7 +85,7 @@ class RepoBuildModulesTableRow extends Component {
   render() {
     const {data, params} = this.props;
     return (
-      <tr className={tableRowBuildState(data.state)}>
+      <tr onClick={this.onTableClick.bind(this)}className={this.getRowClassNames(data.state)}>
         <td className='build-status'>
           {buildResultIcon(data.state)}
         </td>
@@ -83,6 +106,10 @@ class RepoBuildModulesTableRow extends Component {
   }
 
 }
+
+RepoBuildModulesTableRow.contextTypes = {
+  router: PropTypes.object.isRequired
+};
 
 RepoBuildModulesTableRow.propTypes = {
   data: PropTypes.object.isRequired

--- a/BlazarUI/app/scripts/components/repo/BranchesTableRow.jsx
+++ b/BlazarUI/app/scripts/components/repo/BranchesTableRow.jsx
@@ -5,6 +5,7 @@ import {LABELS, iconStatus} from '../constants';
 import {has} from 'underscore';
 import {tableRowBuildState, humanizeText, timestampFormatted, buildResultIcon, timestampDuration} from '../Helpers';
 import moment from 'moment';
+import classNames from 'classnames';
 
 import Icon from '../shared/Icon.jsx';
 import Sha from '../shared/Sha.jsx';
@@ -15,7 +16,9 @@ let initialState = {
 
 class BranchesTableRow extends Component {
 
-  constructor() {
+  constructor(props, context) {
+    super(props, context);
+
     this.state = initialState;
   }
 
@@ -33,13 +36,34 @@ class BranchesTableRow extends Component {
     })
   }
 
+  getRowClassNames(state) {
+    return classNames([
+      tableRowBuildState(state),
+      'clickable-table-row'
+    ]);
+  }
+
+  onTableClick(blazarBranchPath, blazarPath, e) {
+    if (e.target.className === 'sha-link') {
+      window.open(e.target.href, '_blank');
+    }
+
+    else if (e.target.className === 'branch-link') {
+      this.context.router.push(blazarBranchPath);
+    }
+
+    else if (blazarPath !== undefined) {
+      this.context.router.push(blazarPath);
+    }
+  }
+
   renderBranchLink(gitInfo) {
     const {gitInfo} = this.props.data;
 
     return (
       <span>
         <Icon for='branch' classNames="icon-roomy icon-muted" />
-        <Link to={gitInfo.blazarBranchPath}>{gitInfo.branch}</Link>
+        <Link className='branch-link' to={gitInfo.blazarBranchPath}>{gitInfo.branch}</Link>
       </span>
     );
   }
@@ -88,7 +112,7 @@ class BranchesTableRow extends Component {
     }
 
     return (
-      <tr className={tableRowBuildState(build.state)}>
+      <tr onClick={this.onTableClick.bind(this, gitInfo.blazarBranchPath, build.blazarPath)} className={this.getRowClassNames(build.state)}>
         <td className='build-status'>
           {buildResultIcon(build.state)}
         </td>
@@ -121,6 +145,10 @@ class BranchesTableRow extends Component {
   }
 
 }
+
+BranchesTableRow.contextTypes = {
+  router: PropTypes.object.isRequired
+};
 
 BranchesTableRow.propTypes = {
   data: PropTypes.object.isRequired

--- a/BlazarUI/app/stylus/components/branch-build-history.styl
+++ b/BlazarUI/app/stylus/components/branch-build-history.styl
@@ -1,2 +1,0 @@
-.branch-build-history-row
-  cursor pointer

--- a/BlazarUI/app/stylus/components/clickable-table-row.styl
+++ b/BlazarUI/app/stylus/components/clickable-table-row.styl
@@ -1,0 +1,2 @@
+.clickable-table-row
+  cursor pointer

--- a/BlazarUI/app/stylus/main.styl
+++ b/BlazarUI/app/stylus/main.styl
@@ -15,13 +15,13 @@
 // styles that may be overidden
 @import 'components/filter'
 //
-@import 'components/branch-build-history'
 @import 'components/breadcrumb'
 @import 'components/build-detail'
 @import 'components/building-icon'
 @import 'components/build-log'
 @import 'components/build-log-navigation'
 @import 'components/branch-filter'
+@import 'components/clickable-table-row'
 @import 'components/collapsable'
 @import 'components/commits'
 @import 'components/dashboard'


### PR DESCRIPTION
Most tables have a link to most recent build, so that's what I set the default link to be for each row. That applies to all table rows except for the repo-build-module table, which will link to the module's build log