### PR TITLE
Add new WAITING_FOR_UPSTREAM_BUILD state

### DIFF
--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/ModuleBuild.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/ModuleBuild.java
@@ -9,17 +9,34 @@ import com.hubspot.rosetta.annotations.StoredAsJson;
 import java.util.Objects;
 
 public class ModuleBuild {
+  public enum SimpleState { WAITING, RUNNING, COMPLETE }
+
   public enum State {
-    QUEUED(false), LAUNCHING(false), IN_PROGRESS(false), SUCCEEDED(true), CANCELLED(true), FAILED(true), SKIPPED(true);
+    QUEUED(SimpleState.WAITING),
+    WAITING_FOR_UPSTREAM_BUILD(SimpleState.WAITING),
+    LAUNCHING(SimpleState.RUNNING),
+    IN_PROGRESS(SimpleState.RUNNING),
+    SUCCEEDED(SimpleState.COMPLETE),
+    CANCELLED(SimpleState.COMPLETE),
+    FAILED(SimpleState.COMPLETE),
+    SKIPPED(SimpleState.COMPLETE);
 
-    private final boolean completed;
+    private final SimpleState simpleState;
 
-    State(boolean completed) {
-      this.completed = completed;
+    State(SimpleState simpleState) {
+      this.simpleState = simpleState;
+    }
+
+    public boolean isWaiting() {
+      return simpleState == SimpleState.WAITING;
+    }
+
+    public boolean isRunning() {
+      return simpleState == SimpleState.RUNNING;
     }
 
     public boolean isComplete() {
-      return completed;
+      return simpleState == SimpleState.COMPLETE;
     }
   }
 

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/visitor/AbstractModuleBuildVisitor.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/visitor/AbstractModuleBuildVisitor.java
@@ -10,6 +10,9 @@ public abstract class AbstractModuleBuildVisitor implements ModuleBuildVisitor {
       case QUEUED:
         visitQueued(build);
         break;
+      case WAITING_FOR_UPSTREAM_BUILD:
+        visitWaitingForUpstreamBuild(build);
+        break;
       case LAUNCHING:
         visitLaunching(build);
         break;
@@ -34,6 +37,7 @@ public abstract class AbstractModuleBuildVisitor implements ModuleBuildVisitor {
   }
 
   protected void visitQueued(ModuleBuild build) throws Exception {}
+  protected void visitWaitingForUpstreamBuild(ModuleBuild build) throws Exception {}
   protected void visitLaunching(ModuleBuild build) throws Exception {}
   protected void visitInProgress(ModuleBuild build) throws Exception {}
   protected void visitSucceeded(ModuleBuild build) throws Exception {}

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/dao/ModuleBuildDao.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/dao/ModuleBuildDao.java
@@ -50,12 +50,12 @@ public interface ModuleBuildDao {
   @SqlUpdate("INSERT INTO module_builds (repoBuildId, moduleId, buildNumber, state) VALUES (:repoBuildId, :moduleId, :buildNumber, :state)")
   long enqueue(@BindWithRosetta ModuleBuild build);
 
-  @SqlUpdate("UPDATE module_builds SET startTimestamp = :startTimestamp, state = :state, buildConfig = :buildConfig, resolvedConfig = :resolvedConfig WHERE id = :id AND state = 'QUEUED'")
+  @SqlUpdate("UPDATE module_builds SET startTimestamp = :startTimestamp, state = :state, buildConfig = :buildConfig, resolvedConfig = :resolvedConfig WHERE id = :id AND state IN ('QUEUED', 'WAITING_FOR_UPSTREAM_BUILD')")
   int begin(@BindWithRosetta ModuleBuild build);
 
-  @SqlUpdate("UPDATE module_builds SET taskId = :taskId, state = :state WHERE id = :id AND state IN ('LAUNCHING', 'IN_PROGRESS')")
+  @SqlUpdate("UPDATE module_builds SET taskId = :taskId, state = :state WHERE id = :id AND state IN ('QUEUED', 'WAITING_FOR_UPSTREAM_BUILD', 'LAUNCHING', 'IN_PROGRESS')")
   int update(@BindWithRosetta ModuleBuild build);
 
-  @SqlUpdate("UPDATE module_builds SET endTimestamp = :endTimestamp, taskId = :taskId, state = :state WHERE id = :id AND state IN ('QUEUED', 'LAUNCHING', 'IN_PROGRESS')")
+  @SqlUpdate("UPDATE module_builds SET endTimestamp = :endTimestamp, taskId = :taskId, state = :state WHERE id = :id AND state IN ('QUEUED', 'WAITING_FOR_UPSTREAM_BUILD', 'LAUNCHING', 'IN_PROGRESS')")
   int complete(@BindWithRosetta ModuleBuild build);
 }

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/service/ModuleBuildService.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/service/ModuleBuildService.java
@@ -136,7 +136,7 @@ public class ModuleBuildService {
       throw new IllegalStateException(String.format("Build %d has already completed", build.getId().get()));
     }
 
-    if (build.getState() == State.QUEUED) {
+    if (build.getState().isWaiting()) {
       beginNoPublish(build.withState(State.LAUNCHING).withStartTimestamp(System.currentTimeMillis()));
     }
 
@@ -149,7 +149,7 @@ public class ModuleBuildService {
       throw new IllegalStateException(String.format("Build %d has already completed", build.getId().get()));
     }
 
-    if (build.getState() == State.QUEUED) {
+    if (build.getState().isWaiting()) {
       beginNoPublish(build.withState(State.LAUNCHING).withStartTimestamp(System.currentTimeMillis()));
     }
 

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/DownstreamModuleBuildVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/DownstreamModuleBuildVisitor.java
@@ -45,7 +45,7 @@ public class DownstreamModuleBuildVisitor extends AbstractModuleBuildVisitor {
       for (ModuleBuild maybeDownstream : builds) {
         if (downstreamModules.contains(maybeDownstream.getModuleId())) {
           ModuleBuild downstreamBuild = maybeDownstream;
-          if (downstreamBuild.getState() == State.QUEUED) {
+          if (downstreamBuild.getState().isWaiting()) {
             LOG.info("Posting event for downstream build {}", downstreamBuild.getId().get());
             eventBus.post(downstreamBuild);
           } else {


### PR DESCRIPTION
Right now module builds all go to queued state and move to launching as they become ready. Now, everything will leave queued state immediately. If it's ready to build it goes to straight to `LAUNCHING`, otherwise it moves to new `WAITING_FOR_UPSTREAM_BUILD` state