### PR TITLE
Add a few tests for queued builds

### DIFF
--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildOptions.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildOptions.java
@@ -1,10 +1,10 @@
 package com.hubspot.blazar.base;
 
+import java.util.Objects;
 import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
@@ -23,7 +23,7 @@ public class BuildOptions {
   @JsonCreator
   public BuildOptions(@JsonProperty("moduleIds") Set<Integer> moduleIds,
                       @JsonProperty("buildDownstreams") BuildDownstreams buildDownstreams) {
-    this.moduleIds = Objects.firstNonNull(moduleIds, ImmutableSet.<Integer>of());
+    this.moduleIds = com.google.common.base.Objects.firstNonNull(moduleIds, ImmutableSet.<Integer>of());
     this.buildDownstreams = Preconditions.checkNotNull(buildDownstreams);
   }
 
@@ -33,5 +33,24 @@ public class BuildOptions {
 
   public BuildDownstreams getBuildDownstreams() {
     return buildDownstreams;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    BuildOptions that = (BuildOptions) o;
+    return Objects.equals(moduleIds, that.moduleIds) && Objects.equals(buildDownstreams, that.buildDownstreams);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(moduleIds, buildDownstreams);
   }
 }

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildTrigger.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildTrigger.java
@@ -3,6 +3,8 @@ package com.hubspot.blazar.base;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
+import java.util.Objects;
+
 public class BuildTrigger {
   public enum Type {
     PUSH, MANUAL, BRANCH_CREATION
@@ -37,4 +39,22 @@ public class BuildTrigger {
     return id;
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    BuildTrigger that = (BuildTrigger) o;
+    return Objects.equals(type, that.type) && Objects.equals(id, that.id);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(type, id);
+  }
 }

--- a/BlazarData/src/test/java/com/hubspot/blazar/data/service/RepositoryBuildServiceTest.java
+++ b/BlazarData/src/test/java/com/hubspot/blazar/data/service/RepositoryBuildServiceTest.java
@@ -1,0 +1,92 @@
+package com.hubspot.blazar.data.service;
+
+import com.hubspot.blazar.base.BuildOptions;
+import com.hubspot.blazar.base.BuildOptions.BuildDownstreams;
+import com.hubspot.blazar.base.BuildTrigger;
+import com.hubspot.blazar.base.GitInfo;
+import com.hubspot.blazar.base.RepositoryBuild;
+import com.hubspot.blazar.data.BlazarDataTestBase;
+import com.hubspot.blazar.data.util.BuildNumbers;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class RepositoryBuildServiceTest extends BlazarDataTestBase {
+  private RepositoryBuildService repositoryBuildService;
+
+  private GitInfo branchOne;
+  private GitInfo branchTwo;
+
+  @Before
+  public void before() {
+    this.repositoryBuildService = getFromGuice(RepositoryBuildService.class);
+
+    BranchService branchService = getFromGuice(BranchService.class);
+    branchOne = branchService.upsert(GitInfo.fromString("github.com/HubSpot/Test#one"));
+    branchTwo = branchService.upsert(GitInfo.fromString("github.com/HubSpot/Test#two"));
+  }
+
+  @Test
+  public void itEnqueuesNewBuildWhenNonePresent() {
+    BuildTrigger buildTrigger = BuildTrigger.forCommit("abc");
+    BuildOptions buildOptions = new BuildOptions(Collections.singleton(123), BuildDownstreams.NONE);
+    long id = repositoryBuildService.enqueue(branchOne, buildTrigger, buildOptions);
+
+    RepositoryBuild repositoryBuild = repositoryBuildService.get(id).get();
+
+    validateBuild(RepositoryBuild.queuedBuild(branchOne, buildTrigger, 1, buildOptions), repositoryBuild);
+
+    BuildNumbers buildNumbers = repositoryBuildService.getBuildNumbers(branchOne.getId().get());
+    assertThat(buildNumbers.getPendingBuildId().get()).isEqualTo(id);
+    assertThat(buildNumbers.getPendingBuildNumber().get()).isEqualTo(1);
+  }
+
+  @Test
+  public void itReturnsPendingBuildWhenPresent() {
+    BuildTrigger buildTrigger = BuildTrigger.forCommit("abc");
+    BuildOptions buildOptions = new BuildOptions(Collections.singleton(123), BuildDownstreams.NONE);
+    long id = repositoryBuildService.enqueue(branchOne, buildTrigger, buildOptions);
+
+    long otherId = repositoryBuildService.enqueue(branchOne, buildTrigger, buildOptions);
+    assertThat(otherId).isEqualTo(id);
+  }
+
+  @Test
+  public void itEnqueuesNewBuildForDifferentBranch() {
+    BuildTrigger buildTriggerOne = BuildTrigger.forCommit("abc");
+    BuildOptions buildOptionsOne = new BuildOptions(Collections.singleton(123), BuildDownstreams.NONE);
+    long idOne = repositoryBuildService.enqueue(branchOne, buildTriggerOne, buildOptionsOne);
+
+    BuildTrigger buildTriggerTwo = BuildTrigger.forCommit("def");
+    BuildOptions buildOptionsTwo = new BuildOptions(Collections.singleton(456), BuildDownstreams.NONE);
+    long idTwo = repositoryBuildService.enqueue(branchTwo, buildTriggerTwo, buildOptionsTwo);
+
+    assertThat(idTwo).isNotEqualTo(idOne);
+
+    RepositoryBuild repositoryBuild = repositoryBuildService.get(idTwo).get();
+
+    validateBuild(RepositoryBuild.queuedBuild(branchTwo, buildTriggerTwo, 1, buildOptionsTwo), repositoryBuild);
+
+    BuildNumbers buildNumbers = repositoryBuildService.getBuildNumbers(branchTwo.getId().get());
+    assertThat(buildNumbers.getPendingBuildId().get()).isEqualTo(idTwo);
+    assertThat(buildNumbers.getPendingBuildNumber().get()).isEqualTo(1);
+  }
+
+
+
+  private static void validateBuild(RepositoryBuild expected, RepositoryBuild actual) {
+    assertThat(actual.getBranchId()).isEqualTo(expected.getBranchId());
+    assertThat(actual.getBuildNumber()).isEqualTo(expected.getBuildNumber());
+    assertThat(actual.getState()).isEqualTo(expected.getState());
+    assertThat(actual.getBuildTrigger()).isEqualTo(expected.getBuildTrigger());
+    assertThat(actual.getBuildOptions()).isEqualTo(expected.getBuildOptions());
+    assertThat(actual.getStartTimestamp()).isEqualTo(expected.getStartTimestamp());
+    assertThat(actual.getEndTimestamp()).isEqualTo(expected.getEndTimestamp());
+    assertThat(actual.getSha()).isEqualTo(expected.getSha());
+    assertThat(actual.getCommitInfo()).isEqualTo(expected.getCommitInfo());
+    assertThat(actual.getDependencyGraph()).isEqualTo(expected.getDependencyGraph());
+  }
+}

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/QueuedRepositoryBuildVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/QueuedRepositoryBuildVisitor.java
@@ -31,7 +31,8 @@ public class QueuedRepositoryBuildVisitor extends AbstractRepositoryBuildVisitor
     BuildNumbers buildNumbers = repositoryBuildService.getBuildNumbers(build.getBranchId());
 
     if (build.getBuildNumber() != buildNumbers.getPendingBuildNumber().or(-1)) {
-      LOG.info("Build {} is no longer pending for branch {}, not launching", build.getId().get(), build.getBranchId());
+      // now that we allow multiple queued builds this will get hit
+      LOG.info("Build {} is not the pending build for branch {}, not launching", build.getId().get(), build.getBranchId());
     } else if (buildNumbers.getInProgressBuildId().isPresent()) {
       LOG.info("In progress build for branch {}, not launching pending build {}", build.getBranchId(), build.getId().get());
     } else {

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 
     <dep.jackson.version>2.6.4</dep.jackson.version>
     <dep.horizon.version>0.0.24</dep.horizon.version>
-    <dep.rosetta.version>3.10.7</dep.rosetta.version>
+    <dep.rosetta.version>3.10.8</dep.rosetta.version>
     <singularity.version>0.4.9-hs_stable-SNAPSHOT</singularity.version>
     <mesos.version>0.23.0</mesos.version>
     <mesos.docker.tag>0.21.1-1.1.ubuntu1404</mesos.docker.tag>


### PR DESCRIPTION
In preparation for allowing multiple queued builds, start adding some tests for the `RepositoryBuildService`. Required implementing `equals`/`hashCode` in a few places and fixing a bug in Rosetta that happens if you use `@StoredAsJson` on an `Optional` field

@jonathanwgoodwin @gchomatas 