### PR TITLE
make log error more explicit about actions to take

### DIFF
--- a/BlazarUI/app/scripts/data/BuildApi.js
+++ b/BlazarUI/app/scripts/data/BuildApi.js
@@ -332,7 +332,7 @@ class BuildApi {
 
     sizePromise.fail((err) => {
       console.warn('Error requesting log size. ', err);
-      this._buildError('Error accessing build log, or log does not exist (build was not succesfully started). Manually rebuilding is safe, see #Platform-Support if problem persists.');
+      this._buildError('The build log was not found. Most likely, the build failed to start. Try a manual rebuild; if you see this error again, message us in #platform-support.');
     });
 
     return sizePromise;

--- a/BlazarUI/app/scripts/data/BuildApi.js
+++ b/BlazarUI/app/scripts/data/BuildApi.js
@@ -332,7 +332,7 @@ class BuildApi {
 
     sizePromise.fail((err) => {
       console.warn('Error requesting log size. ', err);
-      this._buildError('Error accessing build log, or log does not exist. View console for more detail');
+      this._buildError('Error accessing build log, or log does not exist (build was not succesfully started). Manually rebuilding is safe, see #Platform-Support if problem persists.');
     });
 
     return sizePromise;

--- a/BlazarUI/app/stylus/components/build-log.styl
+++ b/BlazarUI/app/stylus/components/build-log.styl
@@ -26,6 +26,10 @@
     
   .alert
     margin: 10px
+    
+    & p
+      white-space normal
+      word-break break-word
 
 .log-line
   font-size 11px


### PR DESCRIPTION
@zdhickman @jhaber @markhazlewood 

Until we're automatically re-trying tasks that are getting `lost` in singularity we should have a better message here so users know what to do. So far I've only see this error come up when a slave has a hung docker daemon. 