### PR TITLE
Tweaks to the Slack notification for failed builds

### DIFF
--- a/BlazarService/src/main/java/com/hubspot/blazar/integration/slack/SlackClient.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/integration/slack/SlackClient.java
@@ -68,9 +68,7 @@ public class SlackClient {
         throw Throwables.propagate(e);
       }
     }
-    if (message.getIconEmoji().isPresent()) {
-      requestBuilder.setFormParam("icon_emoji").to(message.getIconEmoji().get());
-    }
+    requestBuilder.setFormParam("icon_emoji").to(message.getIconEmoji().or(":fire:"));
 
     asyncHttpClient.execute(requestBuilder.build(), new Callback() {
 

--- a/BlazarService/src/main/java/com/hubspot/blazar/integration/slack/SlackClient.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/integration/slack/SlackClient.java
@@ -68,8 +68,9 @@ public class SlackClient {
         throw Throwables.propagate(e);
       }
     }
-    requestBuilder.setFormParam("icon_emoji").to(message.getIconEmoji().or(":fire:"));
-
+    if (message.getIconEmoji().isPresent()) {
+      requestBuilder.setFormParam("icon_emoji").to(message.getIconEmoji().get());
+    }
     asyncHttpClient.execute(requestBuilder.build(), new Callback() {
 
       @Override


### PR DESCRIPTION
@gchomatas @jhaber @zdhickman @markhazlewood 

Got a notification for a failed build that I didn't cause. Thought it would be nice (for failures) to include the failing / unstable modules in the slack notification. 
Currently the notification looks like this:
<img width="675" alt="screen shot 2016-04-19 at 11 14 11 am" src="https://cloud.githubusercontent.com/assets/3247956/14644386/e5571406-061f-11e6-8ef7-3f7ba865c270.png">

This doesn't change the look of the notification for success.