### PR TITLE
Card improvements

### DIFF
--- a/BlazarUI/app/scripts/components/shared/RepoBranchCard.jsx
+++ b/BlazarUI/app/scripts/components/shared/RepoBranchCard.jsx
@@ -67,7 +67,7 @@ class RepoBranchCard extends Card {
     const gitInfo = item.get('gitInfo');
 
     return (
-      <Link to={gitInfo.get('blazarBranchPath')}>
+      <Link to={gitInfo.get('blazarRepositoryPath')}>
         {gitInfo.get('repository')}
       </Link>
     );

--- a/BlazarUI/app/scripts/components/shared/RepoBranchCard.jsx
+++ b/BlazarUI/app/scripts/components/shared/RepoBranchCard.jsx
@@ -14,9 +14,15 @@ import Sha from '../shared/Sha.jsx';
 class RepoBranchCard extends Card {
 
   getClassNames() {
+    const build = this.getBuildToDisplay();
+    const isFailingBuild = build.get('state') === BuildStates.FAILED
+      || build.get('state') === BuildStates.UNSTABLE;
+
     return classNames([
       this.getBaseClassNames(),
-      'card-stack__card--repo-branch'
+      'card-stack__card--repo-branch', {
+        'repo-branch-card--failed': isFailingBuild
+      }
     ]);
   }
 
@@ -77,7 +83,7 @@ class RepoBranchCard extends Card {
     const {item} = this.props;
     const build = this.getBuildToDisplay();
     const gitInfo = item.get('gitInfo');
-    
+
     return (
       <Link className='repo-branch-card__build-number' to={build.get('blazarPath')}>
         #{build.get('buildNumber')}

--- a/BlazarUI/app/stylus/components/card-stack.styl
+++ b/BlazarUI/app/stylus/components/card-stack.styl
@@ -3,7 +3,7 @@
 // Outer classes
 .card-stack
   width 100%
-  //min-width 800px
+  min-width 800px
   max-width 1500px
   padding 50px 20px
   font-family HelveticaNeue

--- a/BlazarUI/app/stylus/components/card-stack.styl
+++ b/BlazarUI/app/stylus/components/card-stack.styl
@@ -4,7 +4,7 @@
 .card-stack
   width 100%
   //min-width 800px
-  max-width 1350px
+  max-width 1500px
   padding 50px 20px
   font-family HelveticaNeue
 

--- a/BlazarUI/app/stylus/components/repo-branch-card.styl
+++ b/BlazarUI/app/stylus/components/repo-branch-card.styl
@@ -19,19 +19,19 @@
     line-height 50px
 
 .repo-branch-card__header-info
-  width calc(100% / 3)
+  width 30%
 
   &:before
     content 'BRANCH'
 
 .repo-branch-card__header-last-built
-  width calc(100% / 3)
+  width 20%
 
   &:before
     content 'LAST BUILT'
 
 .repo-branch-card__header-details
-  width calc(100% / 3)
+  width 50%
 
   &:before
     content 'DETAILS'
@@ -43,7 +43,7 @@
     content 'STATUS'
 
 .repo-branch-card__info
-  width calc(100% / 3)
+  width 30%
   height 100%
 
 .repo-branch-card__inner-wrapper
@@ -75,10 +75,10 @@
 
 .repo-branch-card__build-and-status--FAILED, .repo-branch-card__build-and-status--UNSTABLE
   background-color #fddbdc
-  
+
 .repo-branch-card__build-and-status--IN_PROGRESS, .repo-branch-card__build-and-status--QUEUED, .repo-branch-card__build-and-status--LAUNCHING, .repo-branch-card__build-and-status--WAITING_FOR_UPSTREAM_BUILD, .repo-branch-card__build-and-status--WAITING_FOR_BUILD_SLOT
   background-color #C5EFFD
-  
+
 .repo-branch-card__build-and-status--CANCELLED
   background-color #FAE0B5
 
@@ -98,7 +98,7 @@
   color #425b76
   background-color #eceef1
   padding 3px 7px
-  
+
   & a
     color #425b76
 
@@ -111,7 +111,7 @@
   color #425b76
 
 .repo-branch-card__last-build
-  width calc(100% / 3)
+  width 20%
   height 100%
   vertical-align middle
   line-height 20px
@@ -125,7 +125,7 @@
   font-family HelveticaNeue-bold
 
 .repo-branch-card__details
-  width calc(100% / 3)
+  width 50%
   height 100%
   vertical-align middle
   line-height 20px
@@ -159,7 +159,7 @@
   font-size 18px
   color #425b76
   display block
-  
+
   & .repo-branch-card__build-number
     font-family HelveticaNeue
 
@@ -180,7 +180,7 @@
   padding 10px
   color #425b76
   transition background $bg-transition-duration
-  
+
   & span
     overflow-y hidden
     text-overflow ellipsis
@@ -204,4 +204,3 @@
 .repo-branch-card__expanded-timestamp
   float right
   max-width 30%
-

--- a/BlazarUI/app/stylus/components/repo-branch-card.styl
+++ b/BlazarUI/app/stylus/components/repo-branch-card.styl
@@ -1,5 +1,9 @@
 @import './card-variables.styl'
 
+$info-width = 25%
+$last-build-width = 20%
+$details-width = 55%
+
 .repo-branch-card__header
   height 50px
   background-color #F9FBFD
@@ -19,31 +23,25 @@
     line-height 50px
 
 .repo-branch-card__header-info
-  width 30%
+  width $info-width
 
   &:before
     content 'BRANCH'
 
 .repo-branch-card__header-last-built
-  width 20%
+  width $last-build-width
 
   &:before
     content 'LAST BUILT'
 
 .repo-branch-card__header-details
-  width 50%
+  width $details-width
 
   &:before
     content 'DETAILS'
 
-.repo-branch-card__header-status
-  width 13%
-
-  &:before
-    content 'STATUS'
-
 .repo-branch-card__info
-  width 30%
+  width $info-width
   height 100%
 
 .repo-branch-card__inner-wrapper
@@ -111,7 +109,7 @@
   color #425b76
 
 .repo-branch-card__last-build
-  width 20%
+  width $last-build-width
   height 100%
   vertical-align middle
   line-height 20px
@@ -125,7 +123,7 @@
   font-family HelveticaNeue-bold
 
 .repo-branch-card__details
-  width 50%
+  width $details-width
   height 100%
   vertical-align middle
   line-height 20px

--- a/BlazarUI/app/stylus/components/repo-branch-card.styl
+++ b/BlazarUI/app/stylus/components/repo-branch-card.styl
@@ -1,8 +1,8 @@
 @import './card-variables.styl'
 
-$info-width = 25%
+$info-width = 30%
 $last-build-width = 20%
-$details-width = 55%
+$details-width = 50%
 
 .repo-branch-card__header
   height 50px

--- a/BlazarUI/app/stylus/components/repo-branch-card.styl
+++ b/BlazarUI/app/stylus/components/repo-branch-card.styl
@@ -204,3 +204,7 @@
 .repo-branch-card__expanded-timestamp
   float right
   max-width 30%
+
+.repo-branch-card--failed
+  & .card-stack__card-main
+    background-color #FFEAEB


### PR DESCRIPTION
- Column widths: 30%, 20%, 50% instead of 33% all around, to match the expected content size. In the future, maybe this can be even more dynamic
- Trying out adding a matching red background to failing build cards
- Make repo name link to repo page instead of branch page

cc @markhazlewood curious about what you think of the background for the card, or if there is a better way of having failing builds stand out