### PR TITLE
typeahead branch selector

### DIFF
--- a/BlazarUI/app/scripts/components/branch/BranchHeadline.jsx
+++ b/BlazarUI/app/scripts/components/branch/BranchHeadline.jsx
@@ -47,6 +47,12 @@ class BranchHeadline extends Component {
   }
 
   onBranchSelect(selected) {
+
+    if (selected === '') {
+      setTimeout(this.forceUpdate.bind(this), 1); // is a hack
+      return;
+    }
+
     const branchLink = `/builds/branch/${selected}`;
     this.context.router.push(branchLink);
   }
@@ -70,10 +76,6 @@ class BranchHeadline extends Component {
   }
 
   renderShield() {
-    if (this.props.loading) {
-      return null;
-    }
-
     const imgPath = `${config.apiRoot}/branches/state/${this.props.params.branchId}/shield?${this.state.moment}`;
 
     return (
@@ -82,7 +84,7 @@ class BranchHeadline extends Component {
       </div>
     );
   }
-    
+
   render() {
     if (this.props.loading) {
       return null;
@@ -93,7 +95,7 @@ class BranchHeadline extends Component {
 
     return (
       <div>
-        <SimpleBreadcrumbs 
+        <SimpleBreadcrumbs
           repo={true}
           {...this.props} />
         <Headline className='headline branch-headline'>
@@ -103,7 +105,6 @@ class BranchHeadline extends Component {
             id={branchId}
           />
           <Icon type="octicon" name="git-branch" classNames="headline-icon" />
-          {this.props.branchInfo.repository} - 
           <Select
             className='branch-select-input'
             name='branchSelect'
@@ -111,8 +112,9 @@ class BranchHeadline extends Component {
             value={this.props.branchInfo.branch}
             options={this.getFilteredBranches()}
             onChange={this.onBranchSelect.bind(this)}
-            searchable={false}
+            searchable={true}
             clearable={false}
+            openOnFocus={true}
           />
           {this.renderShield()}
         </Headline>

--- a/BlazarUI/app/stylus/components/branch-filter.styl
+++ b/BlazarUI/app/stylus/components/branch-filter.styl
@@ -8,24 +8,31 @@
   display inline-block
   margin 0 10px 0 0
 
-.branch-select-input
+/*.branch-select-input
   display inline-block
   margin-left 10px
   position absolute
   top 23px
   min-width 150px
-  
-  & .Select-menu-outer
-    font-size 12px
-    overflow-x hidden
-    
+
     & div
       word-wrap break-word
-    
+
   & .Select-placeholder
     color black
     position relative
     max-width 1150px
-    
+
   & .Select-input
     height 0
+*/
+
+.branch-select-input
+  position absolute
+  left 60px
+  top 23px
+  width 100%
+
+  & .Select-menu-outer
+    font-size 14px
+    overflow-x hidden


### PR DESCRIPTION
For reasons, this is the best we can do with a typeahead selector:

![screen shot 2016-05-06 at 3 07 07 pm](https://cloud.githubusercontent.com/assets/2453653/15083614/37a526e2-139c-11e6-9e2f-42041410a086.png)

It could look better, but react-select styling isn't very intuitive, and this page will be overhauled anyway.

cc @markhazlewood 

I threw this on beta for now