### PR TITLE
Auto trigger

### DIFF
--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/BranchSetting.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/BranchSetting.java
@@ -7,16 +7,19 @@ public class BranchSetting {
 
   private final long branchId;
   private final boolean triggerInterProjectBuilds;
+  private final boolean interProjectBuildOptIn;
 
   @JsonCreator
   public BranchSetting(@JsonProperty("branchId") long branchId,
-                       @JsonProperty("triggerInterProjectBuilds") boolean triggerInterProjectBuilds) {
+                       @JsonProperty("triggerInterProjectBuilds") boolean triggerInterProjectBuilds,
+                       @JsonProperty("interProjectBuildOptIn") boolean interProjectBuildOptIn) {
     this.branchId = branchId;
     this.triggerInterProjectBuilds = triggerInterProjectBuilds;
+    this.interProjectBuildOptIn = interProjectBuildOptIn;
   }
 
   public static BranchSetting getWithDefaultSettings(long branchId) {
-    return new BranchSetting(branchId, false);
+    return new BranchSetting(branchId, false, false);
   }
 
   public long getBranchId() {
@@ -25,5 +28,9 @@ public class BranchSetting {
 
   public boolean isTriggerInterProjectBuilds() {
     return triggerInterProjectBuilds;
+  }
+
+  public boolean isInterProjectBuildOptIn() {
+    return interProjectBuildOptIn;
   }
 }

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/BranchSetting.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/BranchSetting.java
@@ -1,0 +1,29 @@
+package com.hubspot.blazar.base;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class BranchSetting {
+
+  private final long branchId;
+  private final boolean triggerInterProjectBuilds;
+
+  @JsonCreator
+  public BranchSetting(@JsonProperty("branchId") long branchId,
+                       @JsonProperty("triggerInterProjectBuilds") boolean triggerInterProjectBuilds) {
+    this.branchId = branchId;
+    this.triggerInterProjectBuilds = triggerInterProjectBuilds;
+  }
+
+  public static BranchSetting getWithDefaultSettings(long branchId) {
+    return new BranchSetting(branchId, false);
+  }
+
+  public long getBranchId() {
+    return branchId;
+  }
+
+  public boolean isTriggerInterProjectBuilds() {
+    return triggerInterProjectBuilds;
+  }
+}

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildOptions.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildOptions.java
@@ -14,7 +14,7 @@ public class BuildOptions {
   private final boolean resetCaches;
 
   public enum BuildDownstreams {
-    NONE, WITHIN_REPOSITORY;
+    NONE, WITHIN_REPOSITORY, INTER_PROJECT;
   }
 
   public static BuildOptions defaultOptions() {

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/DependencyGraph.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/DependencyGraph.java
@@ -47,6 +47,7 @@ public class DependencyGraph {
 
   public Set<Integer> getAllUpstreamNodes(int moduleId) {
     Stack<Integer> stack = new Stack<>();
+    stack.push(moduleId);
     Set<Integer> seen = new HashSet<>();
     Set<Integer> allIncoming = new HashSet<>();
     while (!stack.empty()) {

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/DependencyGraph.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/DependencyGraph.java
@@ -1,15 +1,16 @@
 package com.hubspot.blazar.base;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
-
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.Stack;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
 
 public class DependencyGraph {
   private final Map<Integer, Set<Integer>> transitiveReduction;
@@ -42,6 +43,28 @@ public class DependencyGraph {
     }
 
     return incomingVertices;
+  }
+
+  public Set<Integer> getAllUpstreamNodes(int moduleId) {
+    Stack<Integer> stack = new Stack<>();
+    Set<Integer> seen = new HashSet<>();
+    Set<Integer> allIncoming = new HashSet<>();
+    while (!stack.empty()) {
+      int i = stack.pop();
+      if (seen.contains(i)) {
+        continue;
+      }
+      seen.add(i);
+      Set<Integer> incoming = incomingVertices(i);
+      allIncoming.addAll(incoming);
+      for (int each : incoming) {
+        if (seen.contains(i)) {
+          continue;
+        }
+        stack.add(each);
+      }
+    }
+    return allIncoming;
   }
 
   public Set<Integer> reachableVertices(int moduleId) {

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/InterProjectBuild.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/InterProjectBuild.java
@@ -59,16 +59,20 @@ public class InterProjectBuild {
     return new InterProjectBuild(Optional.<Long>absent(), State.QUEUED, moduleIds, buildTrigger, Optional.of(System.currentTimeMillis()), Optional.<Long>absent(),Optional.<DependencyGraph>absent());
   }
 
-  public static InterProjectBuild withDependencyGraph(InterProjectBuild old, DependencyGraph d){
-    return new InterProjectBuild(old.getId(), old.getState(), old.getModuleIds(), old.getBuildTrigger(), old.getStartTimestamp(), old.getEndTimestamp(), Optional.of(d));
-  }
-
   public static InterProjectBuild getStarted(InterProjectBuild build) {
     return new InterProjectBuild(build.getId(), State.IN_PROGRESS, build.getModuleIds(), build.getBuildTrigger(), build.getStartTimestamp(), build.getEndTimestamp(), build.getDependencyGraph());
   }
 
   public static InterProjectBuild getFinishedBuild(InterProjectBuild old, State state) {
     return new InterProjectBuild(old.getId(), state, old.getModuleIds(), old.getBuildTrigger(), old.getStartTimestamp(), Optional.of(System.currentTimeMillis()), old.getDependencyGraph());
+  }
+
+  public InterProjectBuild withDependencyGraph(DependencyGraph d){
+    return new InterProjectBuild(id, state, moduleIds, buildTrigger, startTimestamp, endTimestamp, Optional.of(d));
+  }
+
+  public InterProjectBuild withModuleIds(Set<Integer> ids) {
+    return new InterProjectBuild(id, state, ids, buildTrigger, startTimestamp, endTimestamp, dependencyGraph);
   }
 
 

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/BlazarDaoModule.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/BlazarDaoModule.java
@@ -10,6 +10,7 @@ import com.google.inject.Binder;
 import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.hubspot.blazar.data.dao.BranchDao;
+import com.hubspot.blazar.data.dao.BranchSettingsDao;
 import com.hubspot.blazar.data.dao.DependenciesDao;
 import com.hubspot.blazar.data.dao.InterProjectBuildDao;
 import com.hubspot.blazar.data.dao.InterProjectBuildMappingDao;
@@ -45,6 +46,7 @@ public class BlazarDaoModule extends AbstractModule {
     bindDao(binder(), InstantMessageConfigurationDao.class);
     bindDao(binder(), InterProjectBuildDao.class);
     bindDao(binder(), InterProjectBuildMappingDao.class);
+    bindDao(binder(), BranchSettingsDao.class);
   }
 
   private static <T> void bindDao(Binder binder, Class<T> type) {

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/BlazarDataModule.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/BlazarDataModule.java
@@ -3,6 +3,7 @@ package com.hubspot.blazar.data;
 import com.google.inject.AbstractModule;
 import com.hubspot.blazar.data.cache.StateCache;
 import com.hubspot.blazar.data.service.BranchService;
+import com.hubspot.blazar.data.service.BranchSettingsService;
 import com.hubspot.blazar.data.service.DependenciesService;
 import com.hubspot.blazar.data.service.InstantMessageConfigurationService;
 import com.hubspot.blazar.data.service.InterProjectBuildMappingService;
@@ -32,5 +33,6 @@ public class BlazarDataModule extends AbstractModule {
     bind(InstantMessageConfigurationService.class);
     bind(InterProjectBuildService.class);
     bind(InterProjectBuildMappingService.class);
+    bind(BranchSettingsService.class);
   }
 }

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/dao/BranchSettingsDao.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/dao/BranchSettingsDao.java
@@ -16,10 +16,11 @@ public interface BranchSettingsDao {
   Optional<BranchSetting> getByBranchId(@Bind("branchId") int branchId);
 
 
-  @SqlUpdate("INSERT INTO branch_settings (branchId, triggerInterProjectBuilds) VALUES (:branchId, :triggerInterProjectBuilds)")
+  @SqlUpdate("INSERT INTO branch_settings (branchId, triggerInterProjectBuilds, interProjectBuildOptIn) VALUES (:branchId, :triggerInterProjectBuilds, :interProjectBuildOptIn)")
   int insert(@BindWithRosetta BranchSetting branchSetting);
 
-  @SqlUpdate("UPDATE branch_settings set triggerInterProjectBuilds = :triggerInterProjectBuilds where branchId = :branchId")
+  @SqlUpdate("UPDATE branch_settings SET triggerInterProjectBuilds = :triggerInterProjectBuilds, " +
+                                        "interProjectBuildOptIn = :interProjectBuildOptIn " +
+             "WHERE branchId = :branchId")
   int update(@BindWithRosetta BranchSetting branchSetting);
-
 }

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/dao/BranchSettingsDao.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/dao/BranchSettingsDao.java
@@ -1,0 +1,25 @@
+package com.hubspot.blazar.data.dao;
+
+import org.skife.jdbi.v2.sqlobject.Bind;
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+import org.skife.jdbi.v2.sqlobject.SqlUpdate;
+import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
+
+import com.google.common.base.Optional;
+import com.hubspot.blazar.base.BranchSetting;
+import com.hubspot.rosetta.jdbi.BindWithRosetta;
+
+public interface BranchSettingsDao {
+
+  @SingleValueResult
+  @SqlQuery("SELECT * FROM branch_settings where branchId = :branchId")
+  Optional<BranchSetting> getByBranchId(@Bind("branchId") int branchId);
+
+
+  @SqlUpdate("INSERT INTO branch_settings (branchId, triggerInterProjectBuilds) VALUES (:branchId, :triggerInterProjectBuilds)")
+  int insert(@BindWithRosetta BranchSetting branchSetting);
+
+  @SqlUpdate("UPDATE branch_settings set triggerInterProjectBuilds = :triggerInterProjectBuilds where branchId = :branchId")
+  int update(@BindWithRosetta BranchSetting branchSetting);
+
+}

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/dao/DependenciesDao.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/dao/DependenciesDao.java
@@ -1,9 +1,7 @@
 package com.hubspot.blazar.data.dao;
 
-import com.hubspot.blazar.base.GitInfo;
-import com.hubspot.blazar.base.ModuleDependency;
-import com.hubspot.blazar.base.graph.Edge;
-import com.hubspot.rosetta.jdbi.BindWithRosetta;
+import java.util.Set;
+
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlBatch;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
@@ -11,7 +9,10 @@ import org.skife.jdbi.v2.sqlobject.SqlUpdate;
 import org.skife.jdbi.v2.sqlobject.stringtemplate.UseStringTemplate3StatementLocator;
 import org.skife.jdbi.v2.unstable.BindIn;
 
-import java.util.Set;
+import com.hubspot.blazar.base.GitInfo;
+import com.hubspot.blazar.base.ModuleDependency;
+import com.hubspot.blazar.base.graph.Edge;
+import com.hubspot.rosetta.jdbi.BindWithRosetta;
 
 @UseStringTemplate3StatementLocator
 public interface DependenciesDao {
@@ -29,8 +30,10 @@ public interface DependenciesDao {
       "INNER JOIN module_depends ON (module_provides.name = module_depends.name) " +
       "INNER JOIN modules ON (module_depends.moduleId = modules.id) " +
       "INNER JOIN branches ON (modules.branchId = branches.id) " +
+      "LEFT JOIN branch_settings on (branches.id = branch_settings.branchId) " +
       "WHERE module_provides.moduleId IN (<moduleIds>) " +
-      "AND branches.active = 1")
+      "AND branches.active = 1 " +
+      "AND (branches.branch = 'master' OR branch_settings.interProjectBuildOptIn = 1)")
   Set<Edge> getEdges(@BindIn("moduleIds") Set<Integer> moduleIds);
 
   @SqlBatch("INSERT INTO module_provides (moduleId, name) VALUES (:moduleId, :name)")

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/dao/InterProjectBuildDao.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/dao/InterProjectBuildDao.java
@@ -22,6 +22,7 @@ public interface InterProjectBuildDao {
 
   @SqlUpdate("UPDATE inter_project_builds SET " +
              "state = :state, " +
+             "moduleIds = :moduleIds, " +
              "dependencyGraph = :dependencyGraph " +
              "WHERE id = :id and state in ('QUEUED')")
   void start(@BindWithRosetta InterProjectBuild interProjectBuild);

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/service/BranchSettingsService.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/service/BranchSettingsService.java
@@ -1,0 +1,29 @@
+package com.hubspot.blazar.data.service;
+
+import com.google.common.base.Optional;
+import com.google.inject.Inject;
+import com.hubspot.blazar.base.BranchSetting;
+import com.hubspot.blazar.data.dao.BranchSettingsDao;
+
+public class BranchSettingsService {
+
+  private final BranchSettingsDao dao;
+
+  @Inject
+  public BranchSettingsService(BranchSettingsDao dao) {
+    this.dao = dao;
+  }
+
+  public Optional<BranchSetting> getByBranchId(int branchId) {
+    return dao.getByBranchId(branchId);
+  }
+
+  public void insert(BranchSetting branchSetting) {
+    dao.insert(branchSetting);
+  }
+
+  public void update(BranchSetting branchSetting) {
+    dao.update(branchSetting);
+  }
+
+}

--- a/BlazarData/src/main/resources/schema.sql
+++ b/BlazarData/src/main/resources/schema.sql
@@ -186,5 +186,6 @@ CREATE TABLE inter_project_build_mappings (
 CREATE TABLE branch_settings (
   `branchId` INT(11),
   `triggerInterProjectBuilds` TINYINT(1),
+  `interProjectBuildOptIn` TINYINT(1),
   PRIMARY KEY (`branchId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/BlazarData/src/main/resources/schema.sql
+++ b/BlazarData/src/main/resources/schema.sql
@@ -181,3 +181,10 @@ CREATE TABLE inter_project_build_mappings (
   -- INDEX(`interProjectBuildId`, `moduleId`),
   -- INDEX(`interProjectBuildId`, `repoId`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;
+
+--changeset jgoodwin:7 runAlwasy:false
+CREATE TABLE branch_settings (
+  `branchId` INT(11),
+  `triggerInterProjectBuilds` TINYINT(1),
+  PRIMARY KEY (`branchId`)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8;

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectBuildHandler.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectBuildHandler.java
@@ -1,12 +1,9 @@
 package com.hubspot.blazar.listener;
 
-import java.io.IOException;
-import java.nio.file.FileSystems;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
-import org.kohsuke.github.GHRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -17,7 +14,6 @@ import com.google.common.collect.SetMultimap;
 import com.google.inject.Inject;
 import com.hubspot.blazar.base.BuildOptions;
 import com.hubspot.blazar.base.BuildTrigger;
-import com.hubspot.blazar.base.CommitInfo;
 import com.hubspot.blazar.base.DependencyGraph;
 import com.hubspot.blazar.base.GitInfo;
 import com.hubspot.blazar.base.InterProjectBuild;
@@ -29,16 +25,16 @@ import com.hubspot.blazar.data.service.BranchService;
 import com.hubspot.blazar.data.service.DependenciesService;
 import com.hubspot.blazar.data.service.InterProjectBuildMappingService;
 import com.hubspot.blazar.data.service.InterProjectBuildService;
+import com.hubspot.blazar.data.service.ModuleBuildService;
 import com.hubspot.blazar.data.service.ModuleService;
 import com.hubspot.blazar.data.service.RepositoryBuildService;
-import com.hubspot.blazar.exception.NonRetryableBuildException;
-import com.hubspot.blazar.github.GitHubProtos;
 import com.hubspot.blazar.util.GitHubHelper;
 
 public class InterProjectBuildHandler extends AbstractInterProjectBuildVisitor {
   private static final Logger LOG = LoggerFactory.getLogger(InterProjectBuildHandler.class);
   private DependenciesService dependenciesService;
   private ModuleService moduleService;
+  private ModuleBuildService moduleBuildService;
   private BranchService branchService;
   private RepositoryBuildService repositoryBuildService;
   private GitHubHelper gitHubHelper;
@@ -48,6 +44,7 @@ public class InterProjectBuildHandler extends AbstractInterProjectBuildVisitor {
   @Inject
   public InterProjectBuildHandler(DependenciesService dependenciesService,
                                   ModuleService moduleService,
+                                  ModuleBuildService moduleBuildService,
                                   BranchService branchService,
                                   RepositoryBuildService repositoryBuildService,
                                   GitHubHelper gitHubHelper,
@@ -55,6 +52,7 @@ public class InterProjectBuildHandler extends AbstractInterProjectBuildVisitor {
                                   InterProjectBuildService interProjectBuildService){
     this.dependenciesService = dependenciesService;
     this.moduleService = moduleService;
+    this.moduleBuildService = moduleBuildService;
     this.branchService = branchService;
     this.repositoryBuildService = repositoryBuildService;
     this.gitHubHelper = gitHubHelper;
@@ -64,40 +62,6 @@ public class InterProjectBuildHandler extends AbstractInterProjectBuildVisitor {
 
   @Override
   protected void visitQueued(InterProjectBuild build) throws Exception {
-    if (build.getBuildTrigger().getType() == BuildTrigger.Type.PUSH) {
-      handlePushed(build);
-    } else {
-      handleOther(build);
-    }
-  }
-
-  private void handlePushed(InterProjectBuild build) throws Exception {
-    String branchAndSha = build.getBuildTrigger().getId();
-    String[] split = branchAndSha.split("_");
-    if (split.length != 2) {
-      throw new NonRetryableBuildException("Data for InterProject-BuildTrigger is not branchId_sha");
-    }
-    int branchId = Integer.valueOf(split[0]);
-    String beforeSha = branchAndSha.split("_")[1];
-    GitInfo gitInfo = branchService.get(branchId).get();
-    GHRepository repository = gitHubHelper.repositoryFor(gitInfo);
-    Optional<String> currentSha = gitHubHelper.shaFor(repository, gitInfo);
-    LOG.info("Getting changed files for {}#{} {}-{}", gitInfo.getFullRepositoryName(), gitInfo.getBranch(), beforeSha, currentSha);
-    Set<Module> allModules = filterActiveGetId(moduleService.getByBranch(gitInfo.getId().get()));
-    Set<Module> toBuild = getAffectedModules(gitInfo, beforeSha, currentSha, allModules);
-    Set<Integer> toBuildIds = new HashSet<>();
-    for (Module m : toBuild) {
-      toBuildIds.add(m.getId().get());
-    }
-    long start = System.currentTimeMillis();
-    DependencyGraph graph = dependenciesService.buildInterProjectDependencyGraph(toBuild);
-    LOG.debug("Built graph for InterProjectBuild {} in {}", build.getId().get(), System.currentTimeMillis()-start);
-    InterProjectBuild withIdsAndGraph = build.withModuleIds(toBuildIds).withDependencyGraph(graph);
-
-    interProjectBuildService.start(withIdsAndGraph);
-  }
-
-  private void handleOther(InterProjectBuild build) {
     long start = System.currentTimeMillis();
     LOG.info("Building graph for InterProjectBuild {}", build.getId().get());
     Set<Module> s = new HashSet<>();
@@ -113,7 +77,15 @@ public class InterProjectBuildHandler extends AbstractInterProjectBuildVisitor {
   protected void visitRunning(InterProjectBuild build) throws Exception {
     DependencyGraph d = build.getDependencyGraph().get();
     Set<InterProjectBuildMapping> mappings = interProjectBuildMappingService.getMappingsForInterProjectBuild(build);
-    if (!(mappings.size() == 0)) {
+
+    if (mappings.size() != 0 && build.getBuildTrigger().getType() == BuildTrigger.Type.PUSH) {
+      LOG.info("InterProjectBuild was triggered by push, no need to launch builds, mappings exist");
+      return;
+    } else if (mappings.size() == 0 && build.getBuildTrigger().getType() == BuildTrigger.Type.PUSH) {
+      LOG.info("InterProjectBuild was triggered by push, with no child builds triggered, marking as success");
+      interProjectBuildService.finish(InterProjectBuild.getFinishedBuild(build, InterProjectBuild.State.SUCCEEDED));
+      return;
+    } else if (mappings.size() != 0) {
       LOG.warn("Running InterProjectBuild was launched and build mappings created outside of intended flow, Ignoring Event");
       return;
     }
@@ -153,40 +125,4 @@ public class InterProjectBuildHandler extends AbstractInterProjectBuildVisitor {
     }
   }
 
-
-  private Set<Module> getAffectedModules(GitInfo gitInfo, String beforeSha, Optional<String> currentSha, Set<Module> allModules) throws IOException {
-    GHRepository repo = gitHubHelper.repositoryFor(gitInfo);
-    GitHubProtos.Commit beforeCommit = gitHubHelper.toCommit(repo.getCommit(beforeSha));
-    CommitInfo commitInfo;
-    if (currentSha.isPresent()) {
-      GitHubProtos.Commit currentCommit = gitHubHelper.toCommit(repo.getCommit(currentSha.get()));
-      commitInfo = gitHubHelper.commitInfoFor(repo, currentCommit, Optional.of(beforeCommit));
-    } else {
-      commitInfo = gitHubHelper.commitInfoFor(repo, beforeCommit, Optional.<GitHubProtos.Commit>absent());
-    }
-    Set<Module> toBuild = new HashSet<>();
-    if (commitInfo.isTruncated()) {
-      return allModules;
-    } else {
-      for (String path : gitHubHelper.affectedPaths(commitInfo)) {
-        for (Module module : allModules) {
-          if (module.contains(FileSystems.getDefault().getPath(path))) {
-            toBuild.add(module);
-          }
-        }
-      }
-    }
-    return toBuild;
-  }
-
-  private static Set<Module> filterActiveGetId(Set<Module> modules) {
-    Set<Module> filtered = new HashSet<>();
-    for (Module module : modules) {
-      if (module.isActive()) {
-        filtered.add(module);
-      }
-    }
-
-    return filtered;
-  }
 }

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectBuildHandler.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectBuildHandler.java
@@ -77,7 +77,6 @@ public class InterProjectBuildHandler extends AbstractInterProjectBuildVisitor {
   protected void visitRunning(InterProjectBuild build) throws Exception {
     DependencyGraph d = build.getDependencyGraph().get();
     Set<InterProjectBuildMapping> mappings = interProjectBuildMappingService.getMappingsForInterProjectBuild(build);
-
     if (mappings.size() != 0 && build.getBuildTrigger().getType() == BuildTrigger.Type.PUSH) {
       LOG.info("InterProjectBuild was triggered by push, no need to launch builds, mappings exist");
       return;
@@ -124,5 +123,4 @@ public class InterProjectBuildHandler extends AbstractInterProjectBuildVisitor {
       }
     }
   }
-
 }

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectBuildHandler.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectBuildHandler.java
@@ -1,9 +1,12 @@
 package com.hubspot.blazar.listener;
 
+import java.io.IOException;
+import java.nio.file.FileSystems;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 
+import org.kohsuke.github.GHRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -14,6 +17,7 @@ import com.google.common.collect.SetMultimap;
 import com.google.inject.Inject;
 import com.hubspot.blazar.base.BuildOptions;
 import com.hubspot.blazar.base.BuildTrigger;
+import com.hubspot.blazar.base.CommitInfo;
 import com.hubspot.blazar.base.DependencyGraph;
 import com.hubspot.blazar.base.GitInfo;
 import com.hubspot.blazar.base.InterProjectBuild;
@@ -27,6 +31,9 @@ import com.hubspot.blazar.data.service.InterProjectBuildMappingService;
 import com.hubspot.blazar.data.service.InterProjectBuildService;
 import com.hubspot.blazar.data.service.ModuleService;
 import com.hubspot.blazar.data.service.RepositoryBuildService;
+import com.hubspot.blazar.exception.NonRetryableBuildException;
+import com.hubspot.blazar.github.GitHubProtos;
+import com.hubspot.blazar.util.GitHubHelper;
 
 public class InterProjectBuildHandler extends AbstractInterProjectBuildVisitor {
   private static final Logger LOG = LoggerFactory.getLogger(InterProjectBuildHandler.class);
@@ -34,6 +41,7 @@ public class InterProjectBuildHandler extends AbstractInterProjectBuildVisitor {
   private ModuleService moduleService;
   private BranchService branchService;
   private RepositoryBuildService repositoryBuildService;
+  private GitHubHelper gitHubHelper;
   private InterProjectBuildMappingService interProjectBuildMappingService;
   private InterProjectBuildService interProjectBuildService;
 
@@ -42,18 +50,54 @@ public class InterProjectBuildHandler extends AbstractInterProjectBuildVisitor {
                                   ModuleService moduleService,
                                   BranchService branchService,
                                   RepositoryBuildService repositoryBuildService,
+                                  GitHubHelper gitHubHelper,
                                   InterProjectBuildMappingService interProjectBuildMappingService,
                                   InterProjectBuildService interProjectBuildService){
     this.dependenciesService = dependenciesService;
     this.moduleService = moduleService;
     this.branchService = branchService;
     this.repositoryBuildService = repositoryBuildService;
+    this.gitHubHelper = gitHubHelper;
     this.interProjectBuildMappingService = interProjectBuildMappingService;
     this.interProjectBuildService = interProjectBuildService;
   }
 
   @Override
   protected void visitQueued(InterProjectBuild build) throws Exception {
+    if (build.getBuildTrigger().getType() == BuildTrigger.Type.PUSH) {
+      handlePushed(build);
+    } else {
+      handleOther(build);
+    }
+  }
+
+  private void handlePushed(InterProjectBuild build) throws Exception {
+    String branchAndSha = build.getBuildTrigger().getId();
+    String[] split = branchAndSha.split("_");
+    if (split.length != 2) {
+      throw new NonRetryableBuildException("Data for InterProject-BuildTrigger is not branchId_sha");
+    }
+    int branchId = Integer.valueOf(split[0]);
+    String beforeSha = branchAndSha.split("_")[1];
+    GitInfo gitInfo = branchService.get(branchId).get();
+    GHRepository repository = gitHubHelper.repositoryFor(gitInfo);
+    Optional<String> currentSha = gitHubHelper.shaFor(repository, gitInfo);
+    LOG.info("Getting changed files for {}#{} {}-{}", gitInfo.getFullRepositoryName(), gitInfo.getBranch(), beforeSha, currentSha);
+    Set<Module> allModules = filterActiveGetId(moduleService.getByBranch(gitInfo.getId().get()));
+    Set<Module> toBuild = getAffectedModules(gitInfo, beforeSha, currentSha, allModules);
+    Set<Integer> toBuildIds = new HashSet<>();
+    for (Module m : toBuild) {
+      toBuildIds.add(m.getId().get());
+    }
+    long start = System.currentTimeMillis();
+    DependencyGraph graph = dependenciesService.buildInterProjectDependencyGraph(toBuild);
+    LOG.debug("Built graph for InterProjectBuild {} in {}", build.getId().get(), System.currentTimeMillis()-start);
+    InterProjectBuild withIdsAndGraph = build.withModuleIds(toBuildIds).withDependencyGraph(graph);
+
+    interProjectBuildService.start(withIdsAndGraph);
+  }
+
+  private void handleOther(InterProjectBuild build) {
     long start = System.currentTimeMillis();
     LOG.info("Building graph for InterProjectBuild {}", build.getId().get());
     Set<Module> s = new HashSet<>();
@@ -62,9 +106,8 @@ public class InterProjectBuildHandler extends AbstractInterProjectBuildVisitor {
     }
     DependencyGraph d = dependenciesService.buildInterProjectDependencyGraph(s);
     LOG.debug("Built graph for InterProjectBuild {} in {}", build.getId().get(), System.currentTimeMillis()-start);
-    interProjectBuildService.start(InterProjectBuild.withDependencyGraph(build, d));
+    interProjectBuildService.start(build.withDependencyGraph(d));
   }
-
 
   @Override
   protected void visitRunning(InterProjectBuild build) throws Exception {
@@ -108,5 +151,42 @@ public class InterProjectBuildHandler extends AbstractInterProjectBuildVisitor {
         repositoryBuildService.cancel(repositoryBuild);
       }
     }
+  }
+
+
+  private Set<Module> getAffectedModules(GitInfo gitInfo, String beforeSha, Optional<String> currentSha, Set<Module> allModules) throws IOException {
+    GHRepository repo = gitHubHelper.repositoryFor(gitInfo);
+    GitHubProtos.Commit beforeCommit = gitHubHelper.toCommit(repo.getCommit(beforeSha));
+    CommitInfo commitInfo;
+    if (currentSha.isPresent()) {
+      GitHubProtos.Commit currentCommit = gitHubHelper.toCommit(repo.getCommit(currentSha.get()));
+      commitInfo = gitHubHelper.commitInfoFor(repo, currentCommit, Optional.of(beforeCommit));
+    } else {
+      commitInfo = gitHubHelper.commitInfoFor(repo, beforeCommit, Optional.<GitHubProtos.Commit>absent());
+    }
+    Set<Module> toBuild = new HashSet<>();
+    if (commitInfo.isTruncated()) {
+      return allModules;
+    } else {
+      for (String path : gitHubHelper.affectedPaths(commitInfo)) {
+        for (Module module : allModules) {
+          if (module.contains(FileSystems.getDefault().getPath(path))) {
+            toBuild.add(module);
+          }
+        }
+      }
+    }
+    return toBuild;
+  }
+
+  private static Set<Module> filterActiveGetId(Set<Module> modules) {
+    Set<Module> filtered = new HashSet<>();
+    for (Module module : modules) {
+      if (module.isActive()) {
+        filtered.add(module);
+      }
+    }
+
+    return filtered;
   }
 }

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectRepositoryBuildVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectRepositoryBuildVisitor.java
@@ -57,6 +57,11 @@ public class InterProjectRepositoryBuildVisitor extends AbstractRepositoryBuildV
   }
 
   @Override
+  protected void visitUnstable(RepositoryBuild build) throws Exception {
+    checkDone(build);
+  }
+
+  @Override
   protected void visitCancelled(RepositoryBuild build) throws Exception {
     checkDone(build);
   }
@@ -82,8 +87,8 @@ public class InterProjectRepositoryBuildVisitor extends AbstractRepositoryBuildV
         return InterProjectBuild.State.IN_PROGRESS;
       }
 
-      // if there is a failure mark as failed, regardless of any CANCELLED modules
-      if (!mapping.getState().equals(InterProjectBuild.State.SUCCEEDED) && !state.equals(InterProjectBuild.State.FAILED)) {
+      // if there is a failure mark as failed
+      if (mapping.getState() == InterProjectBuild.State.FAILED) {
         state = mapping.getState();
       }
     }

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/LaunchingRepositoryBuildVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/LaunchingRepositoryBuildVisitor.java
@@ -9,11 +9,10 @@ import java.util.Set;
 import javax.inject.Inject;
 import javax.inject.Singleton;
 
-import com.google.common.base.Optional;
-import com.hubspot.blazar.base.ModuleBuild;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.hubspot.blazar.base.BuildOptions.BuildDownstreams;
@@ -21,6 +20,7 @@ import com.hubspot.blazar.base.BuildTrigger.Type;
 import com.hubspot.blazar.base.CommitInfo;
 import com.hubspot.blazar.base.DependencyGraph;
 import com.hubspot.blazar.base.Module;
+import com.hubspot.blazar.base.ModuleBuild;
 import com.hubspot.blazar.base.RepositoryBuild;
 import com.hubspot.blazar.base.RepositoryBuild.State;
 import com.hubspot.blazar.base.visitor.AbstractRepositoryBuildVisitor;

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/QueuedRepositoryBuildVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/QueuedRepositoryBuildVisitor.java
@@ -1,16 +1,17 @@
 package com.hubspot.blazar.listener;
 
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.hubspot.blazar.base.RepositoryBuild;
 import com.hubspot.blazar.base.visitor.AbstractRepositoryBuildVisitor;
 import com.hubspot.blazar.data.service.RepositoryBuildService;
 import com.hubspot.blazar.data.util.BuildNumbers;
 import com.hubspot.blazar.util.RepositoryBuildLauncher;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
 
 @Singleton
 public class QueuedRepositoryBuildVisitor extends AbstractRepositoryBuildVisitor {

--- a/BlazarService/src/main/java/com/hubspot/blazar/resources/BranchResource.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/resources/BranchResource.java
@@ -119,9 +119,9 @@ public class BranchResource {
   public void updateSetting(@PathParam("id") int branchId, BranchSetting branchSetting) {
     Optional<BranchSetting> maybeBranchSetting = branchSettingsService.getByBranchId(branchId);
     if (maybeBranchSetting.isPresent()) {
-      branchSettingsService.update(new BranchSetting(branchId, branchSetting.isTriggerInterProjectBuilds()));
+      branchSettingsService.update(new BranchSetting(branchId, branchSetting.isTriggerInterProjectBuilds(), branchSetting.isInterProjectBuildOptIn()));
     } else {
-      branchSettingsService.insert(new BranchSetting(branchId, branchSetting.isTriggerInterProjectBuilds()));
+      branchSettingsService.insert(new BranchSetting(branchId, branchSetting.isTriggerInterProjectBuilds(), branchSetting.isInterProjectBuildOptIn()));
     }
   }
 }

--- a/BlazarService/src/test/java/com/hubspot/blazar/BlazarServiceTestModule.java
+++ b/BlazarService/src/test/java/com/hubspot/blazar/BlazarServiceTestModule.java
@@ -94,8 +94,8 @@ public class BlazarServiceTestModule extends AbstractModule {
     return new EventBus() {
       @Override
       public void post(Object event) {
-        super.post(event);
         LOG.info("Got event {}", event);
+        super.post(event);
       }
     };
   }

--- a/BlazarService/src/test/java/com/hubspot/blazar/service/InterProjectBuildServiceTest.java
+++ b/BlazarService/src/test/java/com/hubspot/blazar/service/InterProjectBuildServiceTest.java
@@ -104,6 +104,7 @@ public class InterProjectBuildServiceTest extends BlazarServiceTestBase {
     InterProjectBuild testableBuild = runInterProjectBuild(rootModuleId, Optional.of(trigger));
     // commit 11111111* affects modules 1, 2, 3
     assertThat(Sets.newHashSet(1, 2, 3)).isEqualTo(testableBuild.getModuleIds());
+    assertThat(Arrays.asList(1, 2, 4, 5, 7, 6, 8, 10, 11, 9, 13)).isEqualTo(testableBuild.getDependencyGraph().get().getTopologicalSort());
   }
 
   @Test
@@ -114,7 +115,7 @@ public class InterProjectBuildServiceTest extends BlazarServiceTestBase {
     BuildTrigger trigger = new BuildTrigger(BuildTrigger.Type.PUSH, String.format("%d_%s", repoId, sha));
     InterProjectBuild testableBuild = runInterProjectBuild(rootModuleId, Optional.of(trigger));
     assertThat(Sets.newHashSet(1, 2, 3)).isEqualTo(testableBuild.getModuleIds());
-    assertThat(Arrays.asList(1, 4, 7, 8, 10, 11, 9, 13)).isEqualTo(testableBuild.getDependencyGraph().get().getTopologicalSort());
+    assertThat(Arrays.asList(1, 2, 4, 5, 7, 6, 8, 10, 11, 9, 13)).isEqualTo(testableBuild.getDependencyGraph().get().getTopologicalSort());
   }
 
 

--- a/BlazarService/src/test/java/com/hubspot/blazar/service/InterProjectBuildServiceTest.java
+++ b/BlazarService/src/test/java/com/hubspot/blazar/service/InterProjectBuildServiceTest.java
@@ -1,7 +1,7 @@
 package com.hubspot.blazar.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.Fail.fail;
 
 import java.util.Arrays;
 import java.util.Set;
@@ -15,15 +15,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Sets;
 import com.google.inject.Inject;
 import com.hubspot.blazar.BlazarServiceTestBase;
 import com.hubspot.blazar.BlazarServiceTestModule;
+import com.hubspot.blazar.base.BuildOptions;
 import com.hubspot.blazar.base.BuildTrigger;
 import com.hubspot.blazar.base.DependencyGraph;
+import com.hubspot.blazar.base.GitInfo;
 import com.hubspot.blazar.base.InterProjectBuild;
 import com.hubspot.blazar.base.InterProjectBuildMapping;
 import com.hubspot.blazar.base.Module;
+import com.hubspot.blazar.base.RepositoryBuild;
 import com.hubspot.blazar.data.service.BranchService;
 import com.hubspot.blazar.data.service.DependenciesService;
 import com.hubspot.blazar.data.service.InterProjectBuildMappingService;
@@ -59,6 +63,8 @@ public class InterProjectBuildServiceTest extends BlazarServiceTestBase {
   private ModuleBuildService moduleBuildService;
   @Inject
   private SingularityBuildLauncher singularityBuildLauncher;
+  @Inject
+  private TestUtils testUtils;
 
   @Before
   public void before() throws Exception {
@@ -84,7 +90,7 @@ public class InterProjectBuildServiceTest extends BlazarServiceTestBase {
   public void testSuccessfulInterProjectBuild() throws Exception {
     ((TestSingularityBuildLauncher) singularityBuildLauncher).clearModulesToFail();
     // Trigger interProjectBuild
-    InterProjectBuild testableBuild = runInterProjectBuild(1, Optional.<BuildTrigger>absent());
+    InterProjectBuild testableBuild = testUtils.runInterProjectBuild(1, Optional.<BuildTrigger>absent());
     long buildId = testableBuild.getId().get();
     assertThat(Sets.newHashSet(1)).isEqualTo(testableBuild.getModuleIds());
     assertThat(InterProjectBuild.State.SUCCEEDED).isEqualTo(testableBuild.getState());
@@ -96,40 +102,37 @@ public class InterProjectBuildServiceTest extends BlazarServiceTestBase {
   }
 
   @Test
-  public void testInterProjectBuildFromPushWithDiff() throws Exception {
-    int rootModuleId = 1;
+  public void testInterProjectBuildFromPush() throws Exception {
     int repoId = 1;
     String sha = "0000000000000000000000000000000000000000";
-    BuildTrigger trigger = new BuildTrigger(BuildTrigger.Type.PUSH, String.format("%d_%s", repoId, sha));
-    InterProjectBuild testableBuild = runInterProjectBuild(rootModuleId, Optional.of(trigger));
-    // commit 11111111* affects modules 1, 2, 3
-    assertThat(Sets.newHashSet(1, 2, 3)).isEqualTo(testableBuild.getModuleIds());
-    assertThat(Arrays.asList(1, 2, 4, 5, 7, 6, 8, 10, 11, 9, 13)).isEqualTo(testableBuild.getDependencyGraph().get().getTopologicalSort());
-  }
+    branchService.get(1);
+    GitInfo gitInfo = branchService.get(repoId).get();
+    BuildTrigger buildTrigger = BuildTrigger.forCommit(sha);
+    BuildOptions buildOptions = new BuildOptions(ImmutableSet.<Integer>of(), BuildOptions.BuildDownstreams.INTER_PROJECT, false);
+    RepositoryBuild repositoryBuild = testUtils.runAndWaitForRepositoryBuild(gitInfo, buildTrigger, buildOptions);
+    Set<InterProjectBuildMapping> interProjectBuildMappings = interProjectBuildMappingService.getByRepoBuildId(repositoryBuild.getId().get());
+    if (interProjectBuildMappings.isEmpty()) {
+      fail(String.format("Expected to have mappings for repo build %s", repositoryBuild));
+    }
 
-  @Test
-  public void testInterProjectBuildFromPushOfLatestCommit() throws Exception {
-    int rootModuleId = 1;
-    int repoId = 1;
-    String sha = "1000000000000000000000000000000000000001";
-    BuildTrigger trigger = new BuildTrigger(BuildTrigger.Type.PUSH, String.format("%d_%s", repoId, sha));
-    InterProjectBuild testableBuild = runInterProjectBuild(rootModuleId, Optional.of(trigger));
-    assertThat(Sets.newHashSet(1, 2, 3)).isEqualTo(testableBuild.getModuleIds());
-    assertThat(Arrays.asList(1, 2, 4, 5, 7, 6, 8, 10, 11, 9, 13)).isEqualTo(testableBuild.getDependencyGraph().get().getTopologicalSort());
-  }
+    Optional<InterProjectBuild> interProjectBuild = interProjectBuildService.getWithId(interProjectBuildMappings.iterator().next().getInterProjectBuildId());
+    if (!interProjectBuild.isPresent()) {
+      fail(String.format("InterProjectBuild for mapping %s should be present", interProjectBuildMappings.iterator().next()));
+    }
 
+    assertThat(Sets.newHashSet(1, 2, 3)).isEqualTo(interProjectBuild.get().getModuleIds());
+    assertThat(Arrays.asList(1, 2, 4, 5, 7, 6, 8, 10, 11, 9, 13)).isEqualTo(interProjectBuild.get().getDependencyGraph().get().getTopologicalSort());
+  }
 
   @Test
   public void testInterProjectBuildWithFailures() throws Exception {
     Set<Integer> expectedFailures = Sets.newHashSet(7);
     Set<Integer> expectedSuccess  = Sets.newHashSet(1, 4);
     Set<Integer> expectedCancel = Sets.newHashSet(8, 9, 10, 11, 13);
-
-    LOG.info("Initial builds are now in the db\n\n\n");
     ((TestSingularityBuildLauncher) singularityBuildLauncher).setModulesToFail(expectedFailures);
     // Cause module #10 to fail, causing 13 to be cancelled
 
-    InterProjectBuild testableBuild = runInterProjectBuild(1, Optional.<BuildTrigger>absent());
+    InterProjectBuild testableBuild = testUtils.runInterProjectBuild(1, Optional.<BuildTrigger>absent());
     InterProjectBuild buildRun = interProjectBuildService.getWithId(testableBuild.getId().get()).get();
     assertThat(buildRun.getState()).isEqualTo(InterProjectBuild.State.FAILED);
     Set<InterProjectBuildMapping> mappings = interProjectBuildMappingService.getMappingsForInterProjectBuild(buildRun);
@@ -144,27 +147,5 @@ public class InterProjectBuildServiceTest extends BlazarServiceTestBase {
     }
   }
 
-  private InterProjectBuild runInterProjectBuild(int rootModuleId, Optional<BuildTrigger> triggerOptional) throws InterruptedException {
-    BuildTrigger trigger;
-    if (triggerOptional.isPresent()) {
-      trigger = triggerOptional.get();
-    } else {
-      trigger = new BuildTrigger(BuildTrigger.Type.MANUAL, String.format("Test inter-project build root: %d", rootModuleId));
-    }
-    LOG.info("Starting inter-project-build for id {}", rootModuleId);
-    InterProjectBuild build = InterProjectBuild.getQueuedBuild(Sets.newHashSet(rootModuleId), trigger);
-    long id = interProjectBuildService.enqueue(build);
-    Optional<InterProjectBuild> maybeQueued = interProjectBuildService.getWithId(id);
-    int count = 0;
-    // wait 1s for build to finish
-    while (!maybeQueued.isPresent() && !maybeQueued.get().getState().isFinished()) {
-      if (count > 1) {
-        fail("InterProject did not finish in 10s");
-      }
-      count++;
-      Thread.sleep(1000);
-      maybeQueued = interProjectBuildService.getWithId(id);
-    }
-    return maybeQueued.get();
-  }
+
 }

--- a/BlazarService/src/test/java/com/hubspot/blazar/service/InterProjectBuildServiceTest.java
+++ b/BlazarService/src/test/java/com/hubspot/blazar/service/InterProjectBuildServiceTest.java
@@ -122,6 +122,7 @@ public class InterProjectBuildServiceTest extends BlazarServiceTestBase {
 
     assertThat(Sets.newHashSet(1, 2, 3)).isEqualTo(interProjectBuild.get().getModuleIds());
     assertThat(Arrays.asList(1, 2, 4, 5, 7, 6, 8, 10, 11, 9, 13)).isEqualTo(interProjectBuild.get().getDependencyGraph().get().getTopologicalSort());
+    assertThat(interProjectBuild.get().getState()).isEqualTo(InterProjectBuild.State.SUCCEEDED);
   }
 
   @Test

--- a/BlazarService/src/test/java/com/hubspot/blazar/service/InterProjectBuildServiceTest.java
+++ b/BlazarService/src/test/java/com/hubspot/blazar/service/InterProjectBuildServiceTest.java
@@ -146,7 +146,6 @@ public class InterProjectBuildServiceTest extends BlazarServiceTestBase {
         assertThat(mapping.getState().equals(InterProjectBuild.State.SUCCEEDED));
       }
     }
+    ((TestSingularityBuildLauncher) singularityBuildLauncher).clearModulesToFail();
   }
-
-
 }

--- a/BlazarService/src/test/java/com/hubspot/blazar/service/RepositoryBuildTest.java
+++ b/BlazarService/src/test/java/com/hubspot/blazar/service/RepositoryBuildTest.java
@@ -1,7 +1,6 @@
 package com.hubspot.blazar.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.junit.Assert.fail;
 
 import org.jukito.JukitoRunner;
 import org.jukito.UseModules;
@@ -13,12 +12,9 @@ import com.google.common.collect.Lists;
 import com.google.inject.Inject;
 import com.hubspot.blazar.BlazarServiceTestBase;
 import com.hubspot.blazar.BlazarServiceTestModule;
-import com.hubspot.blazar.base.BuildOptions;
-import com.hubspot.blazar.base.BuildTrigger;
 import com.hubspot.blazar.base.GitInfo;
 import com.hubspot.blazar.base.RepositoryBuild;
 import com.hubspot.blazar.data.service.BranchService;
-import com.hubspot.blazar.data.service.RepositoryBuildService;
 import com.hubspot.blazar.listener.BuildEventDispatcher;
 
 @RunWith(JukitoRunner.class)
@@ -31,7 +27,7 @@ public class RepositoryBuildTest extends BlazarServiceTestBase {
   @Inject
   private BranchService branchService;
   @Inject
-  private RepositoryBuildService repositoryBuildService;
+  private TestUtils testUtils;
 
   @Before
   public void before() throws Exception {
@@ -43,26 +39,9 @@ public class RepositoryBuildTest extends BlazarServiceTestBase {
   @Test
   public void testRepositoryBuild() throws InterruptedException {
     GitInfo gitInfo = branchService.get(3).get();
-    RepositoryBuild build = runAndWaitForRepositoryBuild(gitInfo, BuildTrigger.forCommit("1111111111111111111111111111111111111111"), BuildOptions.defaultOptions());
+    RepositoryBuild build = testUtils.runDefaultRepositoryBuild(gitInfo);
     assertThat(build.getBranchId()).isEqualTo(3);
     assertThat(build.getState()).isEqualTo(RepositoryBuild.State.SUCCEEDED);
     assertThat(build.getDependencyGraph().get().getTopologicalSort()).isEqualTo(Lists.newArrayList(7,8,9));
   }
-
-
-  private RepositoryBuild runAndWaitForRepositoryBuild(GitInfo gitInfo, BuildTrigger buildTrigger, BuildOptions buildOptions) throws InterruptedException {
-    long id = repositoryBuildService.enqueue(gitInfo, BuildTrigger.forCommit("1111111111111111111111111111111111111111"), BuildOptions.defaultOptions());
-    RepositoryBuild build = repositoryBuildService.get(id).get();
-    int count = 0;
-    while (!build.getState().isComplete()) {
-      if (count > 10) {
-        fail(String.format("Build %s took more than 10s to complete", build));
-      }
-      count++;
-      Thread.sleep(1000);
-      build = repositoryBuildService.get(id).get();
-    }
-    return build;
-  }
-
 }

--- a/BlazarService/src/test/java/com/hubspot/blazar/service/RepositoryBuildTest.java
+++ b/BlazarService/src/test/java/com/hubspot/blazar/service/RepositoryBuildTest.java
@@ -1,0 +1,68 @@
+package com.hubspot.blazar.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.Assert.fail;
+
+import org.jukito.JukitoRunner;
+import org.jukito.UseModules;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import com.google.common.collect.Lists;
+import com.google.inject.Inject;
+import com.hubspot.blazar.BlazarServiceTestBase;
+import com.hubspot.blazar.BlazarServiceTestModule;
+import com.hubspot.blazar.base.BuildOptions;
+import com.hubspot.blazar.base.BuildTrigger;
+import com.hubspot.blazar.base.GitInfo;
+import com.hubspot.blazar.base.RepositoryBuild;
+import com.hubspot.blazar.data.service.BranchService;
+import com.hubspot.blazar.data.service.RepositoryBuildService;
+import com.hubspot.blazar.listener.BuildEventDispatcher;
+
+@RunWith(JukitoRunner.class)
+@UseModules({BlazarServiceTestModule.class})
+public class RepositoryBuildTest extends BlazarServiceTestBase {
+
+
+  @Inject
+  private BuildEventDispatcher buildEventDispatcher;
+  @Inject
+  private BranchService branchService;
+  @Inject
+  private RepositoryBuildService repositoryBuildService;
+
+  @Before
+  public void before() throws Exception {
+    // set up the data for these inter-project build tests
+    // todo migrate inter project data to a more common place
+    runSql("InterProjectData.sql");
+  }
+
+  @Test
+  public void testRepositoryBuild() throws InterruptedException {
+    GitInfo gitInfo = branchService.get(3).get();
+    RepositoryBuild build = runAndWaitForRepositoryBuild(gitInfo, BuildTrigger.forCommit("1111111111111111111111111111111111111111"), BuildOptions.defaultOptions());
+    assertThat(build.getBranchId()).isEqualTo(3);
+    assertThat(build.getState()).isEqualTo(RepositoryBuild.State.SUCCEEDED);
+    assertThat(build.getDependencyGraph().get().getTopologicalSort()).isEqualTo(Lists.newArrayList(7,8,9));
+  }
+
+
+  private RepositoryBuild runAndWaitForRepositoryBuild(GitInfo gitInfo, BuildTrigger buildTrigger, BuildOptions buildOptions) throws InterruptedException {
+    long id = repositoryBuildService.enqueue(gitInfo, BuildTrigger.forCommit("1111111111111111111111111111111111111111"), BuildOptions.defaultOptions());
+    RepositoryBuild build = repositoryBuildService.get(id).get();
+    int count = 0;
+    while (!build.getState().isComplete()) {
+      if (count > 10) {
+        fail(String.format("Build %s took more than 10s to complete", build));
+      }
+      count++;
+      Thread.sleep(1000);
+      build = repositoryBuildService.get(id).get();
+    }
+    return build;
+  }
+
+}

--- a/BlazarService/src/test/java/com/hubspot/blazar/service/TestUtils.java
+++ b/BlazarService/src/test/java/com/hubspot/blazar/service/TestUtils.java
@@ -1,0 +1,85 @@
+package com.hubspot.blazar.service;
+
+import static org.assertj.core.api.Fail.fail;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.Sets;
+import com.google.inject.Inject;
+import com.hubspot.blazar.base.BuildOptions;
+import com.hubspot.blazar.base.BuildTrigger;
+import com.hubspot.blazar.base.GitInfo;
+import com.hubspot.blazar.base.InterProjectBuild;
+import com.hubspot.blazar.base.RepositoryBuild;
+import com.hubspot.blazar.data.service.InterProjectBuildService;
+import com.hubspot.blazar.data.service.RepositoryBuildService;
+
+public class TestUtils {
+  private final InterProjectBuildService interProjectBuildService;
+  private final RepositoryBuildService repositoryBuildService;
+
+  public static final Logger LOG = LoggerFactory.getLogger(TestUtils.class);
+
+  @Inject
+  public TestUtils (InterProjectBuildService interProjectBuildService,
+                    RepositoryBuildService repositoryBuildService) {
+    this.interProjectBuildService = interProjectBuildService;
+    this.repositoryBuildService = repositoryBuildService;
+  }
+
+
+
+
+  public InterProjectBuild runInterProjectBuild(int rootModuleId, Optional<BuildTrigger> triggerOptional) throws InterruptedException {
+    BuildTrigger trigger;
+    if (triggerOptional.isPresent()) {
+      trigger = triggerOptional.get();
+    } else {
+      trigger = new BuildTrigger(BuildTrigger.Type.MANUAL, String.format("Test inter-project build root: %d", rootModuleId));
+    }
+    LOG.info("Starting inter-project-build for id {}", rootModuleId);
+    InterProjectBuild build = InterProjectBuild.getQueuedBuild(Sets.newHashSet(rootModuleId), trigger);
+    long id = interProjectBuildService.enqueue(build);
+    return waitForInterProjectBuild(interProjectBuildService.getWithId(id).get());
+  }
+
+  public RepositoryBuild runDefaultRepositoryBuild(GitInfo gitInfo) throws InterruptedException {
+    long id = repositoryBuildService.enqueue(gitInfo, BuildTrigger.forCommit("1111111111111111111111111111111111111111"), BuildOptions.defaultOptions());
+    RepositoryBuild build = repositoryBuildService.get(id).get();
+    return waitForRepositoryBuild(build);
+  }
+
+  public RepositoryBuild runAndWaitForRepositoryBuild(GitInfo gitInfo, BuildTrigger buildTrigger, BuildOptions buildOptions) throws InterruptedException {
+    long id = repositoryBuildService.enqueue(gitInfo, buildTrigger, buildOptions);
+    RepositoryBuild build = repositoryBuildService.get(id).get();
+    return waitForRepositoryBuild(build);
+  }
+
+  public InterProjectBuild waitForInterProjectBuild(InterProjectBuild build) throws InterruptedException {
+    int count = 0;
+    while (!build.getState().isFinished()) {
+      if (count > 10) {
+        fail(String.format("Build %s took more than 10s to complete", build));
+      }
+      count++;
+      Thread.sleep(1000);
+      build = interProjectBuildService.getWithId(build.getId().get()).get();
+    }
+    return build;
+  }
+
+  public RepositoryBuild waitForRepositoryBuild(RepositoryBuild build) throws InterruptedException {
+    int count = 0;
+    while (!build.getState().isComplete()) {
+      if (count > 10) {
+        fail(String.format("Build %s took more than 10s to complete", build));
+      }
+      count++;
+      Thread.sleep(1000);
+      build = repositoryBuildService.get(build.getId().get()).get();
+    }
+    return build;
+  }
+}

--- a/BlazarService/src/test/resources/GitHubData.yaml
+++ b/BlazarService/src/test/resources/GitHubData.yaml
@@ -18,12 +18,47 @@
             - sha: "1111111111111111111111111111111111111111"
               path: "/Module3/.blazar.yaml"
               content: "git/example/com/Repo1/Module3/.blazar.yaml"
+            - sha: "1000000000000000000000000000000000000001"
+              path: "/test2.yaml"
+              content: "/no-content"
+            - sha: "0000000000000000000000000000000000000000"
+              path: "/test.yaml"
+              content: "/no-content"
+
         commits:
+          - sha1: "0000000000000000000000000000000000000000"
+            files:
+              - fileName: "/test.yaml"
+                status: "added"
+            commitShortInfo:
+              message: "commit message"
+              commiter:
+                login: "testy"
+                email: "testy@example.com"
+                timestamp: 1460497106000
+              author:
+                login: "testy"
+                email: "testy@example.com"
+                timestamp: 1460497106000
+          - sha1: "1000000000000000000000000000000000000001"
+            files:
+              - fileName: "/test2.yaml"
+                status: "added"
+            commitShortInfo:
+              message: "commit message"
+              commiter:
+                login: "testy"
+                email: "testy@example.com"
+                timestamp: 1460497106000
+              author:
+                login: "testy"
+                email: "testy@example.com"
+                timestamp: 1460497106000
           - sha1: "1111111111111111111111111111111111111111"
             files:
               - fileName: "/Module1/.blazar.yaml"
                 status: "added"
-              - fileName: "/Module3/.blazar.yaml"
+              - fileName: "/Module2/.blazar.yaml"
                 status: "added"
               - fileName: "/Module3/.blazar.yaml"
                 status: "added"
@@ -37,6 +72,7 @@
                 login: "testy"
                 email: "testy@example.com"
                 timestamp: 1460497106000
+
         branches:
           master:    # branches _actually_ contain commit objects, we fake that to reduce complexity/duplication, this sha must reference a sha provided in the repo commits list
             name: "master"

--- a/BlazarTestBase/src/main/java/org/kohsuke/github/BlazarGHCompare.java
+++ b/BlazarTestBase/src/main/java/org/kohsuke/github/BlazarGHCompare.java
@@ -1,6 +1,46 @@
 package org.kohsuke.github;
 
+import java.io.IOException;
+
 public class BlazarGHCompare extends GHCompare {
+
+  static class Commit extends GHCompare.Commit {
+    private final BlazarGHCompare.InnerCommit innerCommit;
+
+    public Commit (BlazarGHCompare.InnerCommit innerCommit) {
+      this.innerCommit = innerCommit;
+      this.sha = innerCommit.sha;
+    }
+
+    @Override
+    public GHCompare.InnerCommit getCommit() {
+      return innerCommit;
+    }
+
+    @Override
+    public String getSHA1() {
+      return innerCommit.getSha();
+    }
+  }
+
+  private static class InnerCommit extends  GHCompare.InnerCommit {
+    private String url, sha, message;
+    private GHCommit.User author;
+    private GHCommit.User committer;
+    private GHTree tree;
+
+    public InnerCommit (BlazarGHCommit commit) throws IOException {
+      this.sha = commit.getSHA1();
+    }
+
+    @Override
+    public String getSha() {
+      return sha;
+    }
+
+  }
+
+
 
   private Commit[] commits;
 
@@ -11,5 +51,9 @@ public class BlazarGHCompare extends GHCompare {
   @Override
   public Commit[] getCommits() {
     return this.commits;
+  }
+
+  public static Commit makeCommit(BlazarGHCommit commit) throws IOException {
+    return new Commit(new InnerCommit(commit));
   }
 }

--- a/BlazarTestBase/src/main/java/org/kohsuke/github/BlazarGHContent.java
+++ b/BlazarTestBase/src/main/java/org/kohsuke/github/BlazarGHContent.java
@@ -25,6 +25,9 @@ public class BlazarGHContent extends GHContent {
   // lets us specify content w/o making extra yaml keys for a single field object
   public static BlazarGHContent fromString(String path) {
     try {
+      if (path.equals("/no-content")) {
+        return new BlazarGHContent("");
+      }
       return new BlazarGHContent(Resources.toString(Resources.getResource(path), Charsets.UTF_8));
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/BlazarTestBase/src/main/java/org/kohsuke/github/BlazarGHRepository.java
+++ b/BlazarTestBase/src/main/java/org/kohsuke/github/BlazarGHRepository.java
@@ -4,6 +4,7 @@ import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
@@ -12,6 +13,8 @@ import org.slf4j.LoggerFactory;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Objects;
 
 public class BlazarGHRepository extends GHRepository {
   private static final Logger LOG = LoggerFactory.getLogger(BlazarGHRepository.class);
@@ -89,7 +92,19 @@ public class BlazarGHRepository extends GHRepository {
 
   @Override
   public GHCompare getCompare(String id1, String id2) throws IOException {
-    return new BlazarGHCompare(new GHCompare.Commit[0]);
+    List<String> shas = new ArrayList<>();
+    for (BlazarGHCommit commit : commits) {
+      shas.add(commit.getSHA1());
+    }
+    int index1 = shas.indexOf(id1);
+    int index2 = shas.indexOf(id2);
+    List<BlazarGHCommit> compareListWrongType = commits.subList(index1, index2 + 1);
+    List<BlazarGHCompare.Commit> compareList = new ArrayList<>();
+    for (BlazarGHCommit commit : compareListWrongType) {
+      compareList.add(BlazarGHCompare.makeCommit(commit));
+    }
+    BlazarGHCompare.Commit commitArray[] = new BlazarGHCompare.Commit[compareList.size()];
+    return new BlazarGHCompare(compareList.toArray(commitArray));
   }
 
   @Override
@@ -136,4 +151,9 @@ public class BlazarGHRepository extends GHRepository {
     this.host = host;
   }
 
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", fullName).toString();
+  }
 }


### PR DESCRIPTION
@gchomatas 
This lets us trigger inter project builds on push.
A push to a repository queues a Repository Build with `buildDownstreams` set to INTER_PROJECT.

This Pr introduces `buildSettings` that allow us to control the behavior of a branch for various blazar-related things. I chose to leave slack settings as their own thing, because I felt they should be separate from settings that are blazar-centric even though they will (probably) be changed from the same UI.

When that build figures out what modules it will build we [intercept those modules](https://github.com/HubSpot/Blazar/compare/auto-trigger?expand=1#diff-a0ab931df7a3afd4381dc3f1f7457eccR74) to ensure that your push will only trigger the modules that don't depend on external dependencies (solving the external transitive dependency case) we also start an InterProjectBuild with type "PUSH", and associate (using build mappings) the modules we launch with that build.

After that the inter-project builds happens as normal, modules in the pushed-to repo that were not triggered at the start will get triggered as a child build later on down the graph.
