### PR TITLE
Fix interprojectbuild finishing race condition

### DIFF
--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/BuildEventDispatcher.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/BuildEventDispatcher.java
@@ -1,5 +1,13 @@
 package com.hubspot.blazar.listener;
 
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.base.Optional;
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.Subscribe;
@@ -13,12 +21,6 @@ import com.hubspot.blazar.data.service.InterProjectBuildService;
 import com.hubspot.blazar.data.service.ModuleBuildService;
 import com.hubspot.blazar.data.service.RepositoryBuildService;
 import com.hubspot.blazar.exception.NonRetryableBuildException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.Set;
 
 @Singleton
 public class BuildEventDispatcher {
@@ -118,7 +120,7 @@ public class BuildEventDispatcher {
       }
     } catch (NonRetryableBuildException e) {
       LOG.warn("Got non Retryable Exception in InterProjectBuild {}, marking as Finished", build.getId().get());
-      interProjectBuildService.finish(build);
+      interProjectBuildService.finish(InterProjectBuild.getFinishedBuild(build, InterProjectBuild.State.FAILED));
     }
   }
 }

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectRepositoryBuildVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectRepositoryBuildVisitor.java
@@ -6,27 +6,22 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import com.google.inject.Inject;
-import com.hubspot.blazar.base.InterProjectBuild;
 import com.hubspot.blazar.base.InterProjectBuildMapping;
 import com.hubspot.blazar.base.ModuleBuild;
 import com.hubspot.blazar.base.RepositoryBuild;
 import com.hubspot.blazar.base.visitor.AbstractRepositoryBuildVisitor;
 import com.hubspot.blazar.data.service.InterProjectBuildMappingService;
-import com.hubspot.blazar.data.service.InterProjectBuildService;
 import com.hubspot.blazar.data.service.ModuleBuildService;
 
 public class InterProjectRepositoryBuildVisitor extends AbstractRepositoryBuildVisitor {
   private static final Logger LOG = LoggerFactory.getLogger(InterProjectRepositoryBuildVisitor.class);
   private final ModuleBuildService moduleBuildService;
-  private final InterProjectBuildService interProjectBuildService;
   private final InterProjectBuildMappingService interProjectBuildMappingService;
 
   @Inject
   public InterProjectRepositoryBuildVisitor(ModuleBuildService moduleBuildService,
-                                            InterProjectBuildService interProjectBuildService,
                                             InterProjectBuildMappingService interProjectBuildMappingService) {
     this.moduleBuildService = moduleBuildService;
-    this.interProjectBuildService = interProjectBuildService;
     this.interProjectBuildMappingService = interProjectBuildMappingService;
   }
 
@@ -36,62 +31,16 @@ public class InterProjectRepositoryBuildVisitor extends AbstractRepositoryBuildV
     if (mappings.isEmpty()) {
       return;
     }
+    long ipbId = mappings.stream().findAny().get().getInterProjectBuildId();
+    LOG.info("Repo Build {} is part of InterProjectBuild {} creating mappings for triggered modules", build, ipbId);
     Set<ModuleBuild> moduleBuildsTriggered = moduleBuildService.getByRepositoryBuild(build.getId().get());
     for (InterProjectBuildMapping mapping : mappings) {
       for (ModuleBuild moduleBuild : moduleBuildsTriggered) {
         if (mapping.getModuleId() == moduleBuild.getModuleId()) {
+          LOG.debug("RepoBuild {} -> IPB {} -> ModuleBuild -> {}", build, ipbId, moduleBuild.getId().get());
           interProjectBuildMappingService.updateBuilds(mapping.withModuleBuildId(moduleBuild.getId().get()));
         }
       }
     }
-  }
-
-  @Override
-  protected void visitSucceeded(RepositoryBuild build) throws Exception {
-    checkDone(build);
-  }
-
-  @Override
-  protected void visitFailed(RepositoryBuild build) {
-    checkDone(build);
-  }
-
-  @Override
-  protected void visitUnstable(RepositoryBuild build) throws Exception {
-    checkDone(build);
-  }
-
-  @Override
-  protected void visitCancelled(RepositoryBuild build) throws Exception {
-    checkDone(build);
-  }
-
-  private void checkDone(RepositoryBuild build) {
-    Set<InterProjectBuildMapping> repoBuildMappings = interProjectBuildMappingService.getByRepoBuildId(build.getId().get());
-    if (repoBuildMappings.isEmpty()) {
-      return;
-    }
-    InterProjectBuild interProjectBuild = interProjectBuildService.getWithId(repoBuildMappings.iterator().next().getInterProjectBuildId()).get();
-    InterProjectBuild.State complete = checkComplete(interProjectBuild);
-    if (!complete.isFinished()) {
-      return;
-    }
-    interProjectBuildService.finish(InterProjectBuild.getFinishedBuild(interProjectBuild, complete));
-  }
-
-  private InterProjectBuild.State checkComplete(InterProjectBuild build) {
-    Set<InterProjectBuildMapping> mappings = interProjectBuildMappingService.getMappingsForInterProjectBuild(build);
-    InterProjectBuild.State state = InterProjectBuild.State.SUCCEEDED;
-    for (InterProjectBuildMapping mapping: mappings) {
-      if (!mapping.getState().isFinished()) {
-        return InterProjectBuild.State.IN_PROGRESS;
-      }
-
-      // if there is a failure mark as failed
-      if (mapping.getState() == InterProjectBuild.State.FAILED) {
-        state = mapping.getState();
-      }
-    }
-    return state;
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -52,6 +52,7 @@
     <mesos.version>0.23.0</mesos.version>
     <mesos.docker.tag>0.21.1-1.1.ubuntu1404</mesos.docker.tag>
     <dep.guava.version>18.0</dep.guava.version>
+    <project.build.targetJdk>1.8</project.build.targetJdk>
   </properties>
 
   <modules>


### PR DESCRIPTION
Handling the marking of an ipb as finished in the repository build visitor had an unforeseen consequence.
because it uses a different queue than the modulebuild visitors, so builds are being marked as successful when really there is a failed module that has yet to be marked as failed. Moved the logic for marking a ipb as success into the ipb module build visitor to resolve this.

Also moves us to java8