### PR TITLE
Don't spam polling requests for active builds

### DIFF
--- a/BlazarUI/app/scripts/stores/branchStore.js
+++ b/BlazarUI/app/scripts/stores/branchStore.js
@@ -7,16 +7,22 @@ const BranchStore = Reflux.createStore({
 
   listenables: BranchActions,
 
-  init() {  
+  init() {
     this.branchBuildHistory = [];
     this.shouldPoll = true;
+    this.buildHistoryRequest = null;
   },
 
   onLoadBranchBuildHistory(params) {
     this.params = params;
 
-    BranchApi.fetchBranchBuildHistory(params, (resp) => {
+    if (this.buildHistoryRequest) {
+      return;
+    }
+
+    this.buildHistoryRequest = BranchApi.fetchBranchBuildHistory(params, (resp) => {
       this.branchBuildHistory = resp;
+      this.buildHistoryRequest = null;
 
       this.trigger({
         builds: this.branchBuildHistory,

--- a/BlazarUI/app/scripts/stores/branchStore.js
+++ b/BlazarUI/app/scripts/stores/branchStore.js
@@ -10,19 +10,19 @@ const BranchStore = Reflux.createStore({
   init() {
     this.branchBuildHistory = [];
     this.shouldPoll = true;
-    this.buildHistoryRequest = null;
+    this.isRequestingBuildHistory = false;
   },
 
   onLoadBranchBuildHistory(params) {
     this.params = params;
 
-    if (this.buildHistoryRequest) {
+    if (this.isRequestingBuildHistory) {
       return;
     }
 
-    this.buildHistoryRequest = BranchApi.fetchBranchBuildHistory(params, (resp) => {
+    this.isRequestingBuildHistory = BranchApi.fetchBranchBuildHistory(params, (resp) => {
       this.branchBuildHistory = resp;
-      this.buildHistoryRequest = null;
+      this.isRequestingBuildHistory = false;
 
       this.trigger({
         builds: this.branchBuildHistory,

--- a/BlazarUI/app/scripts/stores/repoBuildStore.js
+++ b/BlazarUI/app/scripts/stores/repoBuildStore.js
@@ -10,18 +10,25 @@ const RepoBuildStore = Reflux.createStore({
 
   listenables: RepoBuildActions,
 
-  init() {  
+  init() {
     this.repoBuild = {};
     this.moduleBuilds = [];
     this.shouldPoll = true;
     this.moduleBuildsList = [];
+    this.repoBuildRequest = null;
+    this.moduleBuildsRequest = null;
   },
 
   onLoadRepoBuild(params) {
     this.params = params;
 
-    RepoBuildApi.fetchRepoBuild(params, (resp) => {
+    if (this.repoBuildRequest) {
+      return;
+    }
+
+    this.repoBuildRequest = RepoBuildApi.fetchRepoBuild(params, (resp) => {
       this.repoBuild = resp;
+      this.repoBuildRequest = null;
 
       if (buildIsInactive(this.repoBuild.state)) {
         this.shouldPoll = false;
@@ -46,8 +53,13 @@ const RepoBuildStore = Reflux.createStore({
   onLoadModuleBuilds(params) {
     this.params = params;
 
-    RepoBuildApi.fetchModuleBuilds(params, (resp) => {
+    if (this.moduleBuildsRequest) {
+      return;
+    }
+
+    this.moduleBuildsRequest = RepoBuildApi.fetchModuleBuilds(params, (resp) => {
       this.moduleBuilds = resp;
+      this.moduleBuildsRequest = null;
 
       this.trigger({
         moduleBuilds: this.moduleBuilds,

--- a/BlazarUI/app/scripts/stores/repoBuildStore.js
+++ b/BlazarUI/app/scripts/stores/repoBuildStore.js
@@ -15,20 +15,20 @@ const RepoBuildStore = Reflux.createStore({
     this.moduleBuilds = [];
     this.shouldPoll = true;
     this.moduleBuildsList = [];
-    this.repoBuildRequest = null;
-    this.moduleBuildsRequest = null;
+    this.isRequestingRepoBuild = false;
+    this.isRequestingModuleBuilds = false;
   },
 
   onLoadRepoBuild(params) {
     this.params = params;
 
-    if (this.repoBuildRequest) {
+    if (this.isRequestingRepoBuild) {
       return;
     }
 
-    this.repoBuildRequest = RepoBuildApi.fetchRepoBuild(params, (resp) => {
+    this.isRequestingRepoBuild = RepoBuildApi.fetchRepoBuild(params, (resp) => {
       this.repoBuild = resp;
-      this.repoBuildRequest = null;
+      this.isRequestingRepoBuild = false;
 
       if (buildIsInactive(this.repoBuild.state)) {
         this.shouldPoll = false;
@@ -53,13 +53,13 @@ const RepoBuildStore = Reflux.createStore({
   onLoadModuleBuilds(params) {
     this.params = params;
 
-    if (this.moduleBuildsRequest) {
+    if (this.isRequestingModuleBuilds) {
       return;
     }
 
-    this.moduleBuildsRequest = RepoBuildApi.fetchModuleBuilds(params, (resp) => {
+    this.isRequestingModuleBuilds = RepoBuildApi.fetchModuleBuilds(params, (resp) => {
       this.moduleBuilds = resp;
-      this.moduleBuildsRequest = null;
+      this.isRequestingModuleBuilds = false;
 
       this.trigger({
         moduleBuilds: this.moduleBuilds,


### PR DESCRIPTION
This PR fixes an issue where constant polling during active builds can cause a backlog of API calls if the calls are not completing (network issues, etc.). Now, on the branch and repo-build pages, we will only poll if the previous poll request already completed.

cc @gchomatas @andyhuang91 