### PR TITLE
Some attempt to make slack more reliable and monitor-able

### DIFF
--- a/BlazarService/pom.xml
+++ b/BlazarService/pom.xml
@@ -200,7 +200,7 @@
       <artifactId>joda-time</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.takari.slack</groupId>
+      <groupId>com.github.Ullink</groupId>
       <artifactId>simple-slack-api</artifactId>
     </dependency>
 

--- a/BlazarService/pom.xml
+++ b/BlazarService/pom.xml
@@ -56,6 +56,10 @@
       <artifactId>guava</artifactId>
     </dependency>
     <dependency>
+      <groupId>com.github.rholder</groupId>
+      <artifactId>guava-retrying</artifactId>
+    </dependency>
+    <dependency>
       <groupId>aopalliance</groupId>
       <artifactId>aopalliance</artifactId>
     </dependency>

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackImNotificationVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackImNotificationVisitor.java
@@ -82,7 +82,10 @@ public class SlackImNotificationVisitor implements RepositoryBuildVisitor {
     }
 
     SlackMessageHandle<SlackMessageReply> result = slackSession.get().sendMessageToUser(user.get(), "", attachment);
-    if (!result.getReply().isOk()) {
+    if (result == null) {
+      LOG.warn("Failed to send slack message to user: {} message: {} slack response was null", email, attachment.toString());
+      return false;
+    } else if (!result.getReply().isOk()) {
       LOG.warn("Failed to send slack message to user: {} message: {} error: {}", email, attachment.toString(), result.getReply().getErrorMessage());
       return false;
     }

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackRoomNotificationVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackRoomNotificationVisitor.java
@@ -105,7 +105,10 @@ public class SlackRoomNotificationVisitor implements RepositoryBuildVisitor, Mod
     }
 
     SlackMessageHandle<SlackMessageReply> result = slackSession.get().sendMessage(slackChannel.get(), "", attachment);
-    if (!result.getReply().isOk()) {
+    if (result == null)  {
+      LOG.warn("Failed to send slack message to channel: {} message: {} slack result was null", channelName, attachment.toString());
+      return false;
+    } else if (!result.getReply().isOk()) {
       LOG.warn("Failed to send slack message to channel: {} message: {} error: {}", channelName, attachment.toString(), result.getReply().getErrorMessage());
       return false;
     }

--- a/BlazarService/src/main/java/com/hubspot/blazar/util/SlackUtils.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/util/SlackUtils.java
@@ -156,7 +156,7 @@ public class SlackUtils {
   public static Retryer<Boolean> makeSlackMessageSendingRetryer() {
     return RetryerBuilder.<Boolean>newBuilder()
         .retryIfResult(Predicates.equalTo(Boolean.FALSE))
-        .withWaitStrategy(WaitStrategies.exponentialWait(3000, TimeUnit.MILLISECONDS))
+        .withWaitStrategy(WaitStrategies.fixedWait(1, TimeUnit.SECONDS))
         .build();
   }
 }

--- a/BlazarService/src/main/java/com/hubspot/blazar/util/SlackUtils.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/util/SlackUtils.java
@@ -161,4 +161,5 @@ public class SlackUtils {
         .withStopStrategy(StopStrategies.stopAfterAttempt(3))
         .build();
   }
+
 }

--- a/BlazarService/src/main/java/com/hubspot/blazar/util/SlackUtils.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/util/SlackUtils.java
@@ -1,8 +1,13 @@
 package com.hubspot.blazar.util;
 
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
 
+import com.github.rholder.retry.Retryer;
+import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.WaitStrategies;
 import com.google.common.base.Optional;
+import com.google.common.base.Predicates;
 import com.google.inject.Inject;
 import com.hubspot.blazar.base.GitInfo;
 import com.hubspot.blazar.base.Module;
@@ -148,4 +153,10 @@ public class SlackUtils {
     return new SlackAttachment(title, title, "", "");
   }
 
+  public static Retryer<Boolean> makeSlackMessageSendingRetryer() {
+    return RetryerBuilder.<Boolean>newBuilder()
+        .retryIfResult(Predicates.equalTo(Boolean.FALSE))
+        .withWaitStrategy(WaitStrategies.exponentialWait(3000, TimeUnit.MILLISECONDS))
+        .build();
+  }
 }

--- a/BlazarService/src/main/java/com/hubspot/blazar/util/SlackUtils.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/util/SlackUtils.java
@@ -147,4 +147,5 @@ public class SlackUtils {
   private static SlackAttachment makeAttachment(String title) {
     return new SlackAttachment(title, title, "", "");
   }
+
 }

--- a/BlazarService/src/main/java/com/hubspot/blazar/util/SlackUtils.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/util/SlackUtils.java
@@ -5,6 +5,7 @@ import java.util.concurrent.TimeUnit;
 
 import com.github.rholder.retry.Retryer;
 import com.github.rholder.retry.RetryerBuilder;
+import com.github.rholder.retry.StopStrategies;
 import com.github.rholder.retry.WaitStrategies;
 import com.google.common.base.Optional;
 import com.google.common.base.Predicates;
@@ -157,6 +158,7 @@ public class SlackUtils {
     return RetryerBuilder.<Boolean>newBuilder()
         .retryIfResult(Predicates.equalTo(Boolean.FALSE))
         .withWaitStrategy(WaitStrategies.fixedWait(1, TimeUnit.SECONDS))
+        .withStopStrategy(StopStrategies.stopAfterAttempt(3))
         .build();
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -139,6 +139,11 @@
         <version>0.2.1</version>
       </dependency>
       <dependency>
+        <groupId>com.github.rholder</groupId>
+        <artifactId>guava-retrying</artifactId>
+        <version>1.0.7</version>
+      </dependency>
+      <dependency>
         <groupId>com.hubspot.rosetta</groupId>
         <artifactId>RosettaAnnotations</artifactId>
         <version>${dep.rosetta.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,13 @@
     <tag>HEAD</tag>
   </scm>
 
+  <repositories>
+    <repository>
+      <id>jitpack.io</id>
+      <url>https://jitpack.io</url>
+    </repository>
+  </repositories>
+
   <developers>
     <developer>
       <name>Jonathan Haber</name>
@@ -180,7 +187,7 @@
         <version>4.4.1</version>
       </dependency>
       <dependency>
-        <groupId>io.takari.slack</groupId>
+        <groupId>com.github.Ullink</groupId>
         <artifactId>simple-slack-api</artifactId>
         <version>0.5.1</version>
       </dependency>


### PR DESCRIPTION
Core issue is that we keep not-sending slack messages and not knowing why. There is an `isOk` method on the reply but as stated [here](https://github.com/Ullink/simple-slack-api/issues/39) this is hard to use / find. 

I've done my best to make it better, but without fixing the 2nd problem (below) we cannot get the error message etc.

The secondary issue is we were depending on the jar for `simple-slack-api` from [mvncentral](http://search.maven.org/#artifactdetails%7Cio.takari.slack%7Csimple-slack-api%7C0.5.1%7Ctakari-jar) BUT that jar isn't really the 0.5.1 jar, because it doesn't have the fixes released in 0.5.1.

cc: @gchomatas @jhaber 