### PR TITLE
Branch state by module no gitInfo included

### DIFF
--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/ModuleState.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/ModuleState.java
@@ -7,39 +7,39 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 
 public class ModuleState {
+
   private final Module module;
+  private final Optional<ModuleBuild> lastSuccessfulBuild;
+  private final Optional<ModuleBuild> lastNonSkippedBuild;
   private final Optional<ModuleBuild> lastBuild;
   private final Optional<ModuleBuild> inProgressBuild;
   private final Optional<ModuleBuild> pendingBuild;
 
   @JsonCreator
   public ModuleState(@JsonProperty("module") Module module,
+                     @JsonProperty("lastSuccessfulBuild") Optional<ModuleBuild> lastSuccessfulBuild,
+                     @JsonProperty("lastNonSkippedBuild") Optional<ModuleBuild> lastNonSkippedBuild,
                      @JsonProperty("lastBuild") Optional<ModuleBuild> lastBuild,
                      @JsonProperty("inProgressBuild") Optional<ModuleBuild> inProgressBuild,
                      @JsonProperty("pendingBuild") Optional<ModuleBuild> pendingBuild) {
     this.module = module;
-
-    if (lastBuild.isPresent() && !lastBuild.get().getId().isPresent()) {
-      this.lastBuild = Optional.absent();
-    } else {
-      this.lastBuild = lastBuild;
-    }
-
-    if (inProgressBuild.isPresent() && !inProgressBuild.get().getId().isPresent()) {
-      this.inProgressBuild = Optional.absent();
-    } else {
-      this.inProgressBuild = inProgressBuild;
-    }
-
-    if (pendingBuild.isPresent() && !pendingBuild.get().getId().isPresent()) {
-      this.pendingBuild = Optional.absent();
-    } else {
-      this.pendingBuild = pendingBuild;
-    }
+    this.lastSuccessfulBuild = lastSuccessfulBuild;
+    this.lastNonSkippedBuild = lastNonSkippedBuild;
+    this.lastBuild = lastBuild;
+    this.inProgressBuild = inProgressBuild;
+    this.pendingBuild = pendingBuild;
   }
 
   public Module getModule() {
     return module;
+  }
+
+  public Optional<ModuleBuild> getLastSuccessfulBuild() {
+    return lastSuccessfulBuild;
+  }
+
+  public Optional<ModuleBuild> getLastNonSkippedBuild() {
+    return lastNonSkippedBuild;
   }
 
   public Optional<ModuleBuild> getLastBuild() {
@@ -56,23 +56,20 @@ public class ModuleState {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) {
-      return true;
-    }
-
-    if (o == null || getClass() != o.getClass()) {
-      return false;
-    }
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
 
     ModuleState that = (ModuleState) o;
-    return Objects.equals(module, that.module) &&
-        Objects.equals(lastBuild, that.lastBuild) &&
-        Objects.equals(inProgressBuild, that.inProgressBuild) &&
-        Objects.equals(pendingBuild, that.pendingBuild);
+    return Objects.equals(this.module, that.module) &&
+        Objects.equals(this.lastSuccessfulBuild, that.lastSuccessfulBuild) &&
+        Objects.equals(this.lastNonSkippedBuild, that.lastNonSkippedBuild) &&
+        Objects.equals(this.lastBuild, that.lastNonSkippedBuild) &&
+        Objects.equals(this.inProgressBuild, that.inProgressBuild) &&
+        Objects.equals(this.pendingBuild, that.pendingBuild);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(module, lastBuild, inProgressBuild, pendingBuild);
+    return Objects.hash(module, lastSuccessfulBuild, lastNonSkippedBuild, lastBuild, inProgressBuild, pendingBuild);
   }
 }

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/dao/StateDao.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/dao/StateDao.java
@@ -1,13 +1,16 @@
 package com.hubspot.blazar.data.dao;
 
-import com.google.common.base.Optional;
-import com.hubspot.blazar.base.ModuleState;
-import com.hubspot.blazar.base.RepositoryState;
+import java.util.Set;
+
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
 import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
 
-import java.util.Set;
+import com.google.common.base.Optional;
+import com.hubspot.blazar.base.Module;
+import com.hubspot.blazar.base.ModuleState;
+import com.hubspot.blazar.base.RepositoryState;
+import com.hubspot.rosetta.jdbi.BindWithRosetta;
 
 public interface StateDao {
 
@@ -39,12 +42,23 @@ public interface StateDao {
       "WHERE gitInfo.id = :branchId")
   Optional<RepositoryState> getRepositoryState(@Bind("branchId") int branchId);
 
+  @SingleValueResult
   @SqlQuery("" +
-      "SELECT module.*, lastBuild.*, inProgressBuild.*, pendingBuild.* " +
-      "FROM modules AS module " +
-      "LEFT OUTER JOIN module_builds AS lastBuild ON (module.lastBuildId = lastBuild.id) " +
-      "LEFT OUTER JOIN module_builds AS inProgressBuild ON (module.inProgressBuildId = inProgressBuild.id) " +
-      "LEFT OUTER JOIN module_builds AS pendingBuild ON (module.pendingBuildId = pendingBuild.id) " +
-      "WHERE module.branchId = :branchId")
-  Set<ModuleState> getModuleStatesByBranch(@Bind("branchId") int branchId);
+      "SELECT module.*, " +
+      "     lastSuccessfulBuild.*, " +
+      "     lastNonSkippedBuild.*, " +
+      "     lastBuild.*, " +
+      "     inProgressBuild.*, " +
+      "     pendingBuild.* " +
+      "  FROM modules AS module " +
+      "     LEFT OUTER JOIN module_builds AS lastSuccessfulBuild ON (module.id = lastSuccessfulBuild.moduleId) " +
+      "     LEFT OUTER JOIN module_builds AS lastNonSkippedBuild ON (module.id = lastNonSkippedBuild.moduleId) " +
+      "     LEFT OUTER JOIN module_builds AS lastBuild ON (module.lastBuildId = lastBuild.id) " +
+      "     LEFT OUTER JOIN module_builds AS inProgressBuild ON (module.inProgressBuildId = inProgressBuild.id) " +
+      "     LEFT OUTER JOIN module_builds AS pendingBuild ON (module.pendingBuildId = pendingBuild.id) " +
+      "  WHERE module.id = :id " +
+      "  AND lastNonSkippedBuild.state != 'SKIPPED' " +
+      "  AND lastSuccessfulBuild.state = 'SUCCEEDED' " +
+      "  ORDER BY lastNonSkippedBuild.id DESC, lastSuccessfulBuild.id DESC LIMIT 1")
+  Optional<ModuleState> getModuleStateById(@BindWithRosetta Module module);
 }

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/service/StateService.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/service/StateService.java
@@ -1,21 +1,26 @@
 package com.hubspot.blazar.data.service;
 
+import java.util.HashSet;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
 import com.google.common.base.Optional;
+import com.hubspot.blazar.base.Module;
 import com.hubspot.blazar.base.ModuleState;
 import com.hubspot.blazar.base.RepositoryState;
 import com.hubspot.blazar.data.dao.StateDao;
 
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.Set;
-
 @Singleton
 public class StateService {
   private final StateDao stateDao;
+  private ModuleService moduleService;
 
   @Inject
-  public StateService(StateDao stateDao) {
+  public StateService(StateDao stateDao, ModuleService moduleService) {
     this.stateDao = stateDao;
+    this.moduleService = moduleService;
   }
 
   public Set<RepositoryState> getAllRepositoryStates() {
@@ -31,6 +36,13 @@ public class StateService {
   }
 
   public Set<ModuleState> getModuleStatesByBranch(int branchId) {
-    return stateDao.getModuleStatesByBranch(branchId);
+    Set<ModuleState> states = new HashSet<>();
+    for (Module m : moduleService.getByBranch(branchId)) {
+      Optional<ModuleState> state = stateDao.getModuleStateById(m);
+      if (state.isPresent()) {
+        states.add(state.get());
+      }
+    }
+    return states;
   }
 }

--- a/BlazarService/src/main/java/com/hubspot/blazar/resources/BranchStateResource.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/resources/BranchStateResource.java
@@ -99,7 +99,8 @@ public class BranchStateResource {
   @Path("/{id}/modules")
   @PropertyFiltering
   public Set<ModuleState> getModules(@PathParam("id") int branchId) {
-    return stateService.getModuleStatesByBranch(branchId);
+    Set<ModuleState> states = stateService.getModuleStatesByBranch(branchId);
+    return states;
   }
 
   private static String pickImage(RepositoryBuild.State state) {


### PR DESCRIPTION
@andyhuang91 @zdhickman @gchomatas 

I've upgraded moduleState to include the data that we've discussed is required for the new branch-state-by-module page.

The state now includes 2 new builds that it previously didn't have, `lastNonSkippedBuild`, and `lastSuccessfulBuild`. On the FE you should be able to figure out which of the states for the module card you'll be in by comparing those to the already existing `lastBuild`.
You also have `pendingBuild`, `inProgressBuild` to show, when they're present. 

@gchomatas Serialization question
When `pendingBuild` or `inProgressBuild` are not present they're marked as `Optional#absent`, 
But when the `ModuleState` gets serialized I see in the json returned, preferably those aren't there if they're absent, but I'm not sure how to make them go away. (Note: on the absent object the non-optional int/long id fields are actually 0).
```
pendingBuild: {
repoBuildId: 0,
moduleId: 0,
buildNumber: 0
}
```
