### PR TITLE
malformed file changes

### DIFF
--- a/BlazarUI/app/scripts/components/branch/BranchContainer.jsx
+++ b/BlazarUI/app/scripts/components/branch/BranchContainer.jsx
@@ -270,7 +270,6 @@ class BranchContainer extends Component {
   render() {
     return (
       <PageContainer documentTitle={this.buildDocumentTitle()} classNames={this.getClassNames()}>
-        {this.renderMalformedFileAlert()}
         <UIGrid>
           <UIGridItem size={7}>
             <BranchHeadline
@@ -302,6 +301,7 @@ class BranchContainer extends Component {
             {this.renderBuildSettingsButton()}
           </UIGridItem>
         </UIGrid>
+        {this.renderMalformedFileAlert()}
         <UIGrid>
           <UIGridItem size={12}>
             {this.renderTable()}

--- a/BlazarUI/app/scripts/components/repo-build/RepoBuildContainer.jsx
+++ b/BlazarUI/app/scripts/components/repo-build/RepoBuildContainer.jsx
@@ -161,7 +161,6 @@ class RepoBuildContainer extends Component {
   renderPage() {
     return (
       <div>
-        {this.renderMalformedFileAlert()}
         <UIGrid>
           <UIGridItem size={11}>
             <RepoBuildHeadline
@@ -172,6 +171,7 @@ class RepoBuildContainer extends Component {
             />
           </UIGridItem>
         </UIGrid>
+        {this.renderMalformedFileAlert()}
         <UIGridItem size={12}>
           <RepoBuildDetail
             {...this.props}

--- a/BlazarUI/app/scripts/components/shared/MalformedFileNotification.jsx
+++ b/BlazarUI/app/scripts/components/shared/MalformedFileNotification.jsx
@@ -1,33 +1,22 @@
 import React, {Component, PropTypes} from 'react';
-import {bindAll} from 'underscore';
-import Modal from 'react-bootstrap/lib/Modal';
 import Button from 'react-bootstrap/lib/Button';
 import Alert from 'react-bootstrap/lib/Alert';
 import json2html from 'json-to-html';
+import classNames from 'classnames';
 
 import Icon from '../shared/Icon.jsx';
-
-let initialState = {
-  showModal: false
-}
 
 class MalformedFileNotification extends Component {
 
   constructor() {
-    this.state = initialState;
+    this.state = {expanded: false};
 
-    bindAll(this, 'openModal', 'closeModal');
+    this.toggleExpanded = this.toggleExpanded.bind(this);
   }
 
-  openModal() {
+  toggleExpanded() {
     this.setState({
-      showModal: true
-    });
-  }
-
-  closeModal() {
-    this.setState({
-      showModal: false
+      expanded: !this.state.expanded
     });
   }
 
@@ -48,34 +37,24 @@ class MalformedFileNotification extends Component {
     });
   }
 
-  renderModal() {
+  renderDetails() {
     const numberOfFiles = this.props.malformedFiles.length;
 
     return (
-      <Modal className='malformed-file-modal' show={this.state.showModal} onHide={this.closeModal}>
-        <Modal.Header closeButton>
-          <Modal.Title>
-            Malformed Configuration Files - Action Required
-          </Modal.Title>
-        </Modal.Header>
-        <Modal.Body>
-          This branch contains {this.props.malformedFiles.length} malformed configuration file{numberOfFiles > 0 ? 's' : ''}. You'll need to correct these errors:
-          {this.renderConfigInfo()}
-        </Modal.Body>
-        <Modal.Footer>
-          <Button bsStyle="primary" onClick={this.closeModal}>Okay</Button>
-        </Modal.Footer>
-      </Modal>
+      <div className="malformed-files__details">
+        This branch contains {numberOfFiles} malformed configuration file{numberOfFiles !== 1 && 's'}. You''ll need to correct these errors:
+        {this.renderConfigInfo()}
+      </div>
     );
   }
 
   renderAlert() {
     return (
-      <div onClick={this.openModal} className='malformed-files__alert-wrapper'>
-        <Alert bsStyle='danger' className='malformed-files__alert'>
-          One or more of your config files for this branch is malformed. Click for more details.
-        </Alert>
-      </div>
+      <Alert bsStyle='danger' className={classNames('malformed-files__alert', {expanded: this.state.expanded})}>
+        One or more of your config files for this branch is malformed.
+        <a onClick={this.toggleExpanded} className="pull-right">{this.state.expanded ? 'hide' : 'show'} details</a>
+        {this.state.expanded && this.renderDetails()}
+      </Alert>
     );
   }
 
@@ -89,7 +68,6 @@ class MalformedFileNotification extends Component {
     return (
       <div className="malformed-files">
         {this.renderAlert()}
-        {this.renderModal()}
       </div>
     );
   }
@@ -98,6 +76,6 @@ class MalformedFileNotification extends Component {
 MalformedFileNotification.propTypes = {
   malformedFiles: PropTypes.array.isRequired,
   loading: PropTypes.bool.isRequired
-}
+};
 
 export default MalformedFileNotification;

--- a/BlazarUI/app/stylus/base.styl
+++ b/BlazarUI/app/stylus/base.styl
@@ -9,4 +9,3 @@
 
   td
     font-size 12px
-    

--- a/BlazarUI/app/stylus/components/malformed-file-notification.styl
+++ b/BlazarUI/app/stylus/components/malformed-file-notification.styl
@@ -1,15 +1,18 @@
-.malformed-files__alert-wrapper
-  margin-top 8px
-
 .malformed-files__alert
-  cursor pointer
-  
-  &:hover
-    color darkred
-    
+  margin-top 8px
+  max-height 52px
+  transition max-height 1s ease
+  overflow hidden
+
+  &.expanded
+    max-height 999px
+
+.malformed-files__details
+  margin-top 20px
+
 .malformed-files__file
   padding 10px
-  
+
 .malformed-files__file-contents
   margin-top 5px
   max-height 300px

--- a/BlazarUI/app/stylus/type.styl
+++ b/BlazarUI/app/stylus/type.styl
@@ -21,6 +21,7 @@ h1, h2, h3, h4, h5, h6
 
 a
   letter-spacing .02em
+  cursor pointer
 
 h4
   font-size 16px


### PR DESCRIPTION
- Moves malformed file notification below headlines
- Adds show/hide details link which is the only clickable piece of the alert, like the IPB alert
- Expand the alert inline instead