### PR TITLE
Add PostBuildSteps to BuildConfig

### DIFF
--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildConfig.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildConfig.java
@@ -107,30 +107,4 @@ public class BuildConfig {
     return new BuildConfig(steps, before, after, env, buildDeps, webhooks, cache, buildpack, Optional.of(user), stepActivation, depends, provides);
   }
 
-  public static class PostBuildSteps {
-    private final List<BuildStep> onFailure;
-    private final List<BuildStep> onSuccess;
-    private final List<BuildStep> always;
-
-    @JsonCreator
-    public PostBuildSteps(@JsonProperty("onFailure") List<BuildStep> onFailure,
-                          @JsonProperty("onSuccess") List<BuildStep> onSuccess,
-                          @JsonProperty("always") List<BuildStep> always) {
-      this.onFailure = Objects.firstNonNull(onFailure, Collections.emptyList());
-      this.onSuccess = Objects.firstNonNull(onSuccess, Collections.emptyList());
-      this.always = Objects.firstNonNull(always, Collections.emptyList());
-    }
-
-    public List<BuildStep> getOnFailure() {
-      return onFailure;
-    }
-
-    public List<BuildStep> getOnSuccess() {
-      return onSuccess;
-    }
-
-    public List<BuildStep> getAlways() {
-      return always;
-    }
-  }
 }

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildConfig.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildConfig.java
@@ -13,6 +13,7 @@ import com.google.common.base.Optional;
 public class BuildConfig {
   private final List<BuildStep> steps;
   private final List<BuildStep> before;
+  private final Optional<PostBuildSteps> after;
   private final Map<String, String> env;
   private final List<String> buildDeps;
   private final List<String> webhooks;
@@ -26,6 +27,7 @@ public class BuildConfig {
   @JsonCreator
   public BuildConfig(@JsonProperty("steps") List<BuildStep> steps,
                      @JsonProperty("before") List<BuildStep> before,
+                     @JsonProperty("after") Optional<PostBuildSteps> after,
                      @JsonProperty("env") Map<String, String> env,
                      @JsonProperty("buildDeps") List<String> buildDeps,
                      @JsonProperty("webhooks") List<String> webhooks,
@@ -37,6 +39,7 @@ public class BuildConfig {
                      @JsonProperty("provides") Set<Dependency> provides) {
     this.steps = Objects.firstNonNull(steps, Collections.<BuildStep>emptyList());
     this.before = Objects.firstNonNull(before, Collections.<BuildStep>emptyList());
+    this.after = Objects.firstNonNull(after, Optional.absent());
     this.env = Objects.firstNonNull(env, Collections.<String,String>emptyMap());
     this.buildDeps = Objects.firstNonNull(buildDeps, Collections.<String>emptyList());
     this.webhooks = Objects.firstNonNull(webhooks, Collections.<String>emptyList());
@@ -49,7 +52,7 @@ public class BuildConfig {
   }
 
   public static BuildConfig makeDefaultBuildConfig(){
-    return new BuildConfig(null, null, null, null, null, null, null, null, null, null, null);
+    return new BuildConfig(null, null, null, null, null, null, null, null, null, null, null, null);
   }
 
   public List<BuildStep> getSteps() {
@@ -58,6 +61,10 @@ public class BuildConfig {
 
   public List<BuildStep> getBefore() {
     return before;
+  }
+
+  public Optional<PostBuildSteps> getAfter() {
+    return after;
   }
 
   public Map<String, String> getEnv() {
@@ -97,7 +104,33 @@ public class BuildConfig {
   }
 
   public BuildConfig withUser(String user) {
-    return new BuildConfig(steps, before, env, buildDeps, webhooks, cache, buildpack, Optional.of(user), stepActivation, depends, provides);
+    return new BuildConfig(steps, before, after, env, buildDeps, webhooks, cache, buildpack, Optional.of(user), stepActivation, depends, provides);
   }
 
+  public static class PostBuildSteps {
+    private final List<BuildStep> onFailure;
+    private final List<BuildStep> onSuccess;
+    private final List<BuildStep> always;
+
+    @JsonCreator
+    public PostBuildSteps(@JsonProperty("onFailure") List<BuildStep> onFailure,
+                          @JsonProperty("onSuccess") List<BuildStep> onSuccess,
+                          @JsonProperty("always") List<BuildStep> always) {
+      this.onFailure = Objects.firstNonNull(onFailure, Collections.emptyList());
+      this.onSuccess = Objects.firstNonNull(onSuccess, Collections.emptyList());
+      this.always = Objects.firstNonNull(always, Collections.emptyList());
+    }
+
+    public List<BuildStep> getOnFailure() {
+      return onFailure;
+    }
+
+    public List<BuildStep> getOnSuccess() {
+      return onSuccess;
+    }
+
+    public List<BuildStep> getAlways() {
+      return always;
+    }
+  }
 }

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/PostBuildSteps.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/PostBuildSteps.java
@@ -1,0 +1,38 @@
+package com.hubspot.blazar.base;
+
+import java.util.Collections;
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.Objects;
+
+/**
+ * Steps executed after a build, field of {@link BuildConfig}
+ */
+public class PostBuildSteps {
+  private final List<BuildStep> onFailure;
+  private final List<BuildStep> onSuccess;
+  private final List<BuildStep> always;
+
+  @JsonCreator
+  public PostBuildSteps(@JsonProperty("onFailure") List<BuildStep> onFailure,
+                        @JsonProperty("onSuccess") List<BuildStep> onSuccess,
+                        @JsonProperty("always") List<BuildStep> always) {
+    this.onFailure = Objects.firstNonNull(onFailure, Collections.emptyList());
+    this.onSuccess = Objects.firstNonNull(onSuccess, Collections.emptyList());
+    this.always = Objects.firstNonNull(always, Collections.emptyList());
+  }
+
+  public List<BuildStep> getOnFailure() {
+    return onFailure;
+  }
+
+  public List<BuildStep> getOnSuccess() {
+    return onSuccess;
+  }
+
+  public List<BuildStep> getAlways() {
+    return always;
+  }
+}

--- a/BlazarService/src/main/java/com/hubspot/blazar/util/ModuleBuildLauncher.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/util/ModuleBuildLauncher.java
@@ -94,6 +94,7 @@ public class ModuleBuildLauncher {
   private BuildConfig mergeConfig(BuildConfig primary, BuildConfig secondary) {
     List<BuildStep> steps = primary.getSteps().isEmpty() ? secondary.getSteps() : primary.getSteps();
     List<BuildStep> before = primary.getBefore().isEmpty() ? secondary.getBefore() : primary.getBefore();
+    Optional<BuildConfig.PostBuildSteps> after = primary.getAfter().isPresent() ? primary.getAfter() : secondary.getAfter();
     Map<String, String> env = new LinkedHashMap<>();
     env.putAll(secondary.getEnv());
     env.putAll(primary.getEnv());
@@ -120,7 +121,7 @@ public class ModuleBuildLauncher {
     provides.addAll(primary.getDepends());
     provides.addAll(secondary.getDepends());
 
-    return new BuildConfig(steps, before, env, buildDeps, webhooks, cache, Optional.<GitInfo>absent(), Optional.of(user), stepActivation, depends, provides);
+    return new BuildConfig(steps, before, after, env, buildDeps, webhooks, cache, Optional.<GitInfo>absent(), Optional.of(user), stepActivation, depends, provides);
   }
 
   private BuildConfig configAtSha(GitInfo gitInfo, Module module) throws IOException, NonRetryableBuildException {

--- a/BlazarService/src/main/java/com/hubspot/blazar/util/ModuleBuildLauncher.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/util/ModuleBuildLauncher.java
@@ -25,6 +25,7 @@ import com.hubspot.blazar.base.GitInfo;
 import com.hubspot.blazar.base.Module;
 import com.hubspot.blazar.base.ModuleBuild;
 import com.hubspot.blazar.base.ModuleBuild.State;
+import com.hubspot.blazar.base.PostBuildSteps;
 import com.hubspot.blazar.base.RepositoryBuild;
 import com.hubspot.blazar.base.StepActivationCriteria;
 import com.hubspot.blazar.config.BlazarConfiguration;
@@ -94,7 +95,7 @@ public class ModuleBuildLauncher {
   private BuildConfig mergeConfig(BuildConfig primary, BuildConfig secondary) {
     List<BuildStep> steps = primary.getSteps().isEmpty() ? secondary.getSteps() : primary.getSteps();
     List<BuildStep> before = primary.getBefore().isEmpty() ? secondary.getBefore() : primary.getBefore();
-    Optional<BuildConfig.PostBuildSteps> after = (!primary.getAfter().isPresent()) ? secondary.getAfter() : primary.getAfter();
+    Optional<PostBuildSteps> after = (!primary.getAfter().isPresent()) ? secondary.getAfter() : primary.getAfter();
     Map<String, String> env = new LinkedHashMap<>();
     env.putAll(secondary.getEnv());
     env.putAll(primary.getEnv());

--- a/BlazarService/src/main/java/com/hubspot/blazar/util/ModuleBuildLauncher.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/util/ModuleBuildLauncher.java
@@ -94,7 +94,7 @@ public class ModuleBuildLauncher {
   private BuildConfig mergeConfig(BuildConfig primary, BuildConfig secondary) {
     List<BuildStep> steps = primary.getSteps().isEmpty() ? secondary.getSteps() : primary.getSteps();
     List<BuildStep> before = primary.getBefore().isEmpty() ? secondary.getBefore() : primary.getBefore();
-    Optional<BuildConfig.PostBuildSteps> after = primary.getAfter().isPresent() ? primary.getAfter() : secondary.getAfter();
+    Optional<BuildConfig.PostBuildSteps> after = (!primary.getAfter().isPresent()) ? secondary.getAfter() : primary.getAfter();
     Map<String, String> env = new LinkedHashMap<>();
     env.putAll(secondary.getEnv());
     env.putAll(primary.getEnv());


### PR DESCRIPTION
This gives build configs the option to specify `after` build actions, similar to the `before` actions:
```
after:
    onSuccess: doCelebrationStuff
    onFailure: doFailureStuff
    always: doCleanupStuff
```
More changes need to be made internally.

cc: @jonathanwgoodwin @gchomatas 