### PR TITLE
Prop filters

### DIFF
--- a/BlazarUI/app/scripts/data/BranchApi.js
+++ b/BlazarUI/app/scripts/data/BranchApi.js
@@ -2,6 +2,7 @@ import Resource from '../services/ResourceProvider';
 import { fromJS } from 'immutable';
 import humanizeDuration from 'humanize-duration';
 import { getUsernameFromCookie } from '../components/Helpers.js';
+import $ from 'jquery';
 
 function _parse(params, resp) {
   const builds = resp.map((build) => {
@@ -22,9 +23,26 @@ function _parseModules(resp) {
 }
 
 function fetchBranchBuildHistory(params, cb) {
+  const exclusionOpts = {
+    property: [
+      '!buildTrigger',
+      '!buildOptions',
+      '!dependencyGraph',
+      '!commitInfo.newCommits',
+      '!commitInfo.previous',
+      '!commitInfo.truncated',
+      '!commitInfo.current.author',
+      '!commitInfo.current.committer',
+      '!commitInfo.current.modified',
+      '!commitInfo.current.added',
+      '!commitInfo.current.removed'
+    ]
+  };
+
   const branchBuildHistoryPromise = new Resource({
     url: `${window.config.apiRoot}/builds/history/branch/${params.branchId}`,
-    type: 'GET'
+    type: 'GET',
+    data: $.param(exclusionOpts).replace(/%5B%5D/g, '')
   }).send();
 
   return branchBuildHistoryPromise.then((resp) => {

--- a/BlazarUI/app/scripts/data/BranchApi.js
+++ b/BlazarUI/app/scripts/data/BranchApi.js
@@ -42,7 +42,7 @@ function fetchBranchBuildHistory(params, cb) {
   const branchBuildHistoryPromise = new Resource({
     url: `${window.config.apiRoot}/builds/history/branch/${params.branchId}`,
     type: 'GET',
-    data: $.param(exclusionOpts).replace(/%5B%5D/g, '')
+    data: $.param(exclusionOpts, true)
   }).send();
 
   return branchBuildHistoryPromise.then((resp) => {

--- a/BlazarUI/app/scripts/data/BuildsApi.js
+++ b/BlazarUI/app/scripts/data/BuildsApi.js
@@ -84,7 +84,7 @@ function fetchBuilds(extraData, cb) {
     url: `${window.config.apiRoot}/branches/state`,
     type: 'GET',
     dataType: 'json',
-    data: $.param(exclusionOpts).replace(/%5B%5D/g, '')
+    data: $.param(exclusionOpts, true)
   });
 
   this.buildsPoller.poll((err, resp) => {

--- a/BlazarUI/app/scripts/data/RepoBuildApi.js
+++ b/BlazarUI/app/scripts/data/RepoBuildApi.js
@@ -42,7 +42,7 @@ function _fetchBranchBuildHistory(params) {
   const branchBuildHistoryPromise = new Resource({
     url: `${window.config.apiRoot}/builds/history/branch/${params.branchId}`,
     type: 'GET',
-    data: $.param(inclusionOpts).replace(/%5B%5D/g, '')
+    data: $.param(inclusionOpts, true)
   }).send();
 
   return branchBuildHistoryPromise;

--- a/BlazarUI/app/scripts/data/RepoBuildApi.js
+++ b/BlazarUI/app/scripts/data/RepoBuildApi.js
@@ -2,6 +2,7 @@ import Resource from '../services/ResourceProvider';
 import Q from 'q';
 import { findWhere, map, extend, max, contains } from 'underscore';
 import humanizeDuration from 'humanize-duration';
+import $ from 'jquery';
 
 function _parse(resp) {
   if (resp.startTimestamp && resp.endTimestamp) {
@@ -30,9 +31,18 @@ function _fetchModuleNamesById(branchId) {
 }
 
 function _fetchBranchBuildHistory(params) {
+  const inclusionOpts = {
+    property: [
+      'buildNumber',
+      'id',
+      'state'
+    ]
+  };
+
   const branchBuildHistoryPromise = new Resource({
     url: `${window.config.apiRoot}/builds/history/branch/${params.branchId}`,
-    type: 'GET'
+    type: 'GET',
+    data: $.param(inclusionOpts).replace(/%5B%5D/g, '')
   }).send();
 
   return branchBuildHistoryPromise;


### PR DESCRIPTION
- On the branch build history page, add some exclusion options to our query for the build history so that we're not transferring so much data

- On the repo build page, we actually poll the branch build history in order to find the repo build id. But, we only need three pieces of data: state, build number, and (repo build) id. So add those three _in_clusion opts

cc @andyhuang91 @gchomatas 