### PR TITLE
Fix select module bugs for manual builds

### DIFF
--- a/BlazarUI/app/scripts/components/branch/BranchContainer.jsx
+++ b/BlazarUI/app/scripts/components/branch/BranchContainer.jsx
@@ -37,7 +37,7 @@ const initialState = {
   malformedFiles: [],
   showModuleModal: false,
   modules: [],
-  selectedModules: [],
+  selectedModuleIds: [],
   buildDownstreamModules: 'WITHIN_REPOSITORY',
   triggerInterProjectBuild: false,
   resetCache: false,
@@ -52,7 +52,7 @@ class BranchContainer extends Component {
   constructor() {
     this.state = initialState;
 
-    bindAll(this, 'openModuleModal', 'closeModuleModal', 'onStatusChange', 'updateSelectedModules', 'updateDownstreamModules', 'updateResetCache', 'updateTriggerInterProjectBuild', 'triggerBuild', 'refreshBranches');
+    bindAll(this, 'openModuleModal', 'closeModuleModal', 'onStatusChange', 'updateSelectedModuleIds', 'updateDownstreamModules', 'updateResetCache', 'updateTriggerInterProjectBuild', 'triggerBuild', 'refreshBranches');
   }
 
   componentDidMount() {
@@ -129,7 +129,8 @@ class BranchContainer extends Component {
 
   openModuleModal() {
     this.setState({
-      showModuleModal: true
+      showModuleModal: true,
+      selectedModuleIds: this.state.modules.map((module) => module.id)
     });
   }
 
@@ -139,9 +140,9 @@ class BranchContainer extends Component {
     });
   }
 
-  updateSelectedModules(modules) {
+  updateSelectedModuleIds(moduleIds) {
     this.setState({
-      selectedModules: modules
+      selectedModuleIds: moduleIds
     });
   }
 
@@ -165,18 +166,10 @@ class BranchContainer extends Component {
 
 
   triggerBuild() {
-    const newState = this.state;
-
-    if (this.state.selectedModules.length === 0) {
-      newState.selectedModules = this.state.modules.map((module) => {
-        return module.id;
-      });
-    }
-
     if (this.state.triggerInterProjectBuild) {
-      InterProjectActions.triggerInterProjectBuild(this.props.params, newState);
+      InterProjectActions.triggerInterProjectBuild(this.props.params, this.state);
     } else {
-      BranchActions.triggerBuild(this.props.params, newState);
+      BranchActions.triggerBuild(this.props.params, this.state);
     }
   }
 
@@ -284,11 +277,12 @@ class BranchContainer extends Component {
               showModal={this.state.showModuleModal}
               closeModal={this.closeModuleModal}
               triggerBuild={this.triggerBuild}
-              onSelectUpdate={this.updateSelectedModules}
+              onUpdateSelectedModuleIds={this.updateSelectedModuleIds}
               onCheckboxUpdate={this.updateDownstreamModules}
               onResetCacheUpdate={this.updateResetCache}
               onTriggerInterProjectBuild={this.updateTriggerInterProjectBuild}
               modules={this.state.modules}
+              selectedModuleIds={this.state.selectedModuleIds}
             />
             {this.renderBuildSettingsButton()}
           </UIGridItem>

--- a/BlazarUI/app/scripts/components/shared/ModuleModal.jsx
+++ b/BlazarUI/app/scripts/components/shared/ModuleModal.jsx
@@ -13,17 +13,12 @@ class ModuleModal extends Component {
   constructor(props) {
     super(props);
 
-    bindAll(this, 'updateDownstreamModules', 'updateResetCache', 'updateTriggerInterProjectBuild', 'updateSelectedModules', 'getModuleIdsAndBuild', 'maybeStartBuild');
+    bindAll(this, 'updateDownstreamModules', 'updateResetCache', 'updateTriggerInterProjectBuild', 'getModuleIdsAndBuild', 'maybeStartBuild');
   }
 
   getModuleIdsAndBuild() {
     this.props.triggerBuild();
     this.props.closeModal();
-  }
-
-  updateSelectedModules(modules) {
-    const finalModules = modules.split(',');
-    this.props.onSelectUpdate(finalModules);
   }
 
   updateResetCache() {
@@ -153,7 +148,8 @@ class ModuleModal extends Component {
               <span className="module-modal__text">Choose modules to build:</span>
               <ModuleSelectWrapper
                 modules={this.props.modules}
-                onSelectUpdate={this.updateSelectedModules}
+                selectedModuleIds={this.props.selectedModuleIds}
+                onUpdateSelectedModuleIds={this.props.onUpdateSelectedModuleIds}
               />
             </div>
           </div>
@@ -165,7 +161,7 @@ class ModuleModal extends Component {
         </Modal.Body>
         <Modal.Footer>
           <Button id="module-modal-nevermind-button" onClick={this.props.closeModal}>Nevermind</Button>
-          <Button id="module-modal-build-button" onClick={this.getModuleIdsAndBuild} className="btn btn-primary">Build</Button>
+          <Button id="module-modal-build-button" disabled={!this.props.selectedModuleIds.length} onClick={this.getModuleIdsAndBuild} bsStyle="primary">Build</Button>
         </Modal.Footer>
       </div>
     );
@@ -183,13 +179,14 @@ class ModuleModal extends Component {
 ModuleModal.propTypes = {
   closeModal: PropTypes.func.isRequired,
   triggerBuild: PropTypes.func.isRequired,
-  onSelectUpdate: PropTypes.func.isRequired,
+  onUpdateSelectedModuleIds: PropTypes.func.isRequired,
   onCheckboxUpdate: PropTypes.func.isRequired,
   onResetCacheUpdate: PropTypes.func.isRequired,
   onTriggerInterProjectBuild: PropTypes.func.isRequired,
   showModal: PropTypes.bool.isRequired,
   loadingModules: PropTypes.bool,
-  modules: PropTypes.array.isRequired
+  modules: PropTypes.array.isRequired,
+  selectedModuleIds: PropTypes.arrayOf(PropTypes.number).isRequired
 };
 
 export default ModuleModal;

--- a/BlazarUI/app/scripts/components/shared/ModuleSelectWrapper.jsx
+++ b/BlazarUI/app/scripts/components/shared/ModuleSelectWrapper.jsx
@@ -5,12 +5,17 @@ class ModuleSelectWrapper extends Component {
 
   constructor(props) {
     super(props);
-
-    this.state = {};
+    this.handleChange = this.handleChange.bind(this);
   }
 
   shouldComponentUpdate(nextProps) {
     return nextProps.modules.length !== this.props.modules.length;
+  }
+
+  handleChange(value) {
+    // react-select returns an empty string if nothing is selected
+    const moduleIds = value ? value.split(',').map(Number) : [];
+    this.props.onUpdateSelectedModuleIds(moduleIds);
   }
 
   createModuleSelectOptions(modules) {
@@ -32,9 +37,9 @@ class ModuleSelectWrapper extends Component {
           clearAllText="None"
           noResultsText="All modules have been selected."
           multi={true}
-          value={this.createModuleSelectOptions(this.props.modules)}
+          value={this.props.selectedModuleIds}
           options={this.createModuleSelectOptions(this.props.modules)}
-          onChange={this.props.onSelectUpdate}
+          onChange={this.handleChange}
         />
       </div>
     );
@@ -43,7 +48,8 @@ class ModuleSelectWrapper extends Component {
 
 ModuleSelectWrapper.propTypes = {
   modules: PropTypes.array.isRequired,
-  onSelectUpdate: PropTypes.func.isRequired
+  selectedModuleIds: PropTypes.arrayOf(PropTypes.number).isRequired,
+  onUpdateSelectedModuleIds: PropTypes.func.isRequired
 };
 
 export default ModuleSelectWrapper;

--- a/BlazarUI/app/scripts/stores/branchStore.js
+++ b/BlazarUI/app/scripts/stores/branchStore.js
@@ -80,9 +80,9 @@ const BranchStore = Reflux.createStore({
   },
 
   onTriggerBuild(params, state) {
-    const {selectedModules, buildDownstreamModules, resetCache} = state;
+    const {selectedModuleIds, buildDownstreamModules, resetCache} = state;
 
-    BranchApi.triggerBuild(params, selectedModules, buildDownstreamModules, resetCache, (error) => {
+    BranchApi.triggerBuild(params, selectedModuleIds, buildDownstreamModules, resetCache, (error) => {
       if (error) {
         this.error = error;
         this.triggerErrorUpdate();

--- a/BlazarUI/app/scripts/stores/interProjectStore.js
+++ b/BlazarUI/app/scripts/stores/interProjectStore.js
@@ -14,8 +14,8 @@ const InterProjectStore = Reflux.createStore({
   },
 
   onTriggerInterProjectBuild(params, state) {
-    const {selectedModules, resetCache} = state;
-    InterProjectApi.triggerInterProjectBuild(selectedModules, resetCache, (error) => {
+    const {selectedModuleIds, resetCache} = state;
+    InterProjectApi.triggerInterProjectBuild(selectedModuleIds, resetCache, (error) => {
       if (error) {
         this.error = error;
         this.triggerErrorUpdate();


### PR DESCRIPTION
- Do not send [null] to the api when no modules are selected.
- Disable the build button when no modules are selected.
- Don't build previously selected modules when doing a second manual build
without touching the multi-select.

@jonathanwgoodwin 