### PR TITLE
Use better index

### DIFF
--- a/BlazarData/src/main/java/com/hubspot/blazar/data/dao/RepositoryBuildDao.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/dao/RepositoryBuildDao.java
@@ -2,7 +2,6 @@ package com.hubspot.blazar.data.dao;
 
 import java.util.List;
 
-import com.hubspot.blazar.base.RepositoryBuild.State;
 import org.skife.jdbi.v2.sqlobject.Bind;
 import org.skife.jdbi.v2.sqlobject.GetGeneratedKeys;
 import org.skife.jdbi.v2.sqlobject.SqlQuery;
@@ -11,6 +10,7 @@ import org.skife.jdbi.v2.sqlobject.customizers.SingleValueResult;
 
 import com.google.common.base.Optional;
 import com.hubspot.blazar.base.RepositoryBuild;
+import com.hubspot.blazar.base.RepositoryBuild.State;
 import com.hubspot.blazar.data.util.BuildNumbers;
 import com.hubspot.rosetta.jdbi.BindWithRosetta;
 
@@ -20,7 +20,7 @@ public interface RepositoryBuildDao {
   @SqlQuery("SELECT * FROM repo_builds WHERE id = :id")
   Optional<RepositoryBuild> get(@Bind("id") long id);
 
-  @SqlQuery("SELECT * FROM repo_builds WHERE branchId = :branchId ORDER BY id DESC")
+  @SqlQuery("SELECT * FROM repo_builds WHERE branchId = :branchId ORDER BY buildNumber DESC")
   List<RepositoryBuild> getByBranch(@Bind("branchId") int branchId);
 
   @SqlQuery("SELECT * FROM repo_builds WHERE branchId = :branchId AND state = :state ORDER BY id DESC")


### PR DESCRIPTION
@gchomatas this improves this query to take advantage of the index on `branchId, buildNumber`
Paginating this endpoint is definitely something we should do, but I'm leaving that for another time.

```
mysql> explain SELECT * FROM repo_builds WHERE branchId = 1045 ORDER BY buildNumber DESC\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: repo_builds
   partitions: NULL
         type: ref
possible_keys: branchId
          key: branchId
      key_len: 4
          ref: const
         rows: 2174
     filtered: 100.00
        Extra: Using where
1 row in set, 1 warning (0.00 sec)

mysql> explain SELECT * FROM repo_builds WHERE branchId = 1045 ORDER BY id DESC\G
*************************** 1. row ***************************
           id: 1
  select_type: SIMPLE
        table: repo_builds
   partitions: NULL
         type: ref
possible_keys: branchId
          key: branchId
      key_len: 4
          ref: const
         rows: 2174
     filtered: 100.00
        Extra: Using index condition; Using filesort
1 row in set, 1 warning (0.00 sec)
```