### PR TITLE
Move a bunch of counter metrics to guages / meters

### DIFF
--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/metrics/StateToActiveBuildCountPair.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/metrics/StateToActiveBuildCountPair.java
@@ -1,0 +1,46 @@
+package com.hubspot.blazar.base.metrics;
+
+import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class StateToActiveBuildCountPair {
+
+  private final String stateName;
+  private final Integer count;
+
+  @JsonCreator
+  public StateToActiveBuildCountPair(@JsonProperty("stateName") String stateName,
+                                     @JsonProperty("count") Integer count) {
+    this.stateName = stateName;
+    this.count = count;
+  }
+
+  public String getStateName() {
+    return stateName;
+  }
+
+  public Integer getCount() {
+    return count;
+  }
+
+    @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    StateToActiveBuildCountPair pair = (StateToActiveBuildCountPair) o;
+    return Objects.equals(stateName, pair.stateName) && Objects.equals(count, pair.count);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(stateName, count);
+  }
+}

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/BlazarDaoModule.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/BlazarDaoModule.java
@@ -16,6 +16,7 @@ import com.hubspot.blazar.data.dao.InstantMessageConfigurationDao;
 import com.hubspot.blazar.data.dao.InterProjectBuildDao;
 import com.hubspot.blazar.data.dao.InterProjectBuildMappingDao;
 import com.hubspot.blazar.data.dao.MalformedFileDao;
+import com.hubspot.blazar.data.dao.MetricsDao;
 import com.hubspot.blazar.data.dao.ModuleBuildDao;
 import com.hubspot.blazar.data.dao.ModuleDao;
 import com.hubspot.blazar.data.dao.RepositoryBuildDao;
@@ -48,6 +49,7 @@ public class BlazarDaoModule extends AbstractModule {
     bindDao(binder(), InterProjectBuildDao.class);
     bindDao(binder(), InterProjectBuildMappingDao.class);
     bindDao(binder(), BranchSettingsDao.class);
+    bindDao(binder(), MetricsDao.class);
   }
 
   private static <T> void bindDao(Binder binder, Class<T> type) {

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/BlazarDataModule.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/BlazarDataModule.java
@@ -4,11 +4,13 @@ import com.google.inject.AbstractModule;
 import com.hubspot.blazar.data.cache.StateCache;
 import com.hubspot.blazar.data.service.BranchService;
 import com.hubspot.blazar.data.service.BranchSettingsService;
+import com.hubspot.blazar.data.service.CachingMetricsService;
 import com.hubspot.blazar.data.service.DependenciesService;
 import com.hubspot.blazar.data.service.InstantMessageConfigurationService;
 import com.hubspot.blazar.data.service.InterProjectBuildMappingService;
 import com.hubspot.blazar.data.service.InterProjectBuildService;
 import com.hubspot.blazar.data.service.MalformedFileService;
+import com.hubspot.blazar.data.service.MetricsService;
 import com.hubspot.blazar.data.service.ModuleBuildService;
 import com.hubspot.blazar.data.service.ModuleDiscoveryService;
 import com.hubspot.blazar.data.service.ModuleService;
@@ -34,5 +36,7 @@ public class BlazarDataModule extends AbstractModule {
     bind(InterProjectBuildService.class);
     bind(InterProjectBuildMappingService.class);
     bind(BranchSettingsService.class);
+    bind(MetricsService.class);
+    bind(CachingMetricsService.class);
   }
 }

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/dao/MetricsDao.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/dao/MetricsDao.java
@@ -1,0 +1,19 @@
+package com.hubspot.blazar.data.dao;
+
+import java.util.Set;
+
+import org.skife.jdbi.v2.sqlobject.SqlQuery;
+
+import com.hubspot.blazar.base.metrics.StateToActiveBuildCountPair;
+
+public interface MetricsDao {
+
+  @SqlQuery("SELECT state AS stateName, COUNT(id) AS count FROM module_builds " +
+      "WHERE state IN ('QUEUED', 'WAITING_FOR_UPSTREAM_BUILD', 'LAUNCHING', 'IN_PROGRESS') GROUP BY state")
+  Set<StateToActiveBuildCountPair> countActiveModuleBuildsByState();
+
+  @SqlQuery("SELECT state AS stateName, COUNT(id) AS count FROM repo_builds " +
+      "WHERE state IN ('QUEUED', 'LAUNCHING', 'IN_PROGRESS') GROUP BY state")
+  Set<StateToActiveBuildCountPair> countActiveBranchBuildsByState();
+
+}

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/service/CachingMetricsService.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/service/CachingMetricsService.java
@@ -1,0 +1,54 @@
+package com.hubspot.blazar.data.service;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import com.google.inject.Inject;
+import com.google.inject.Singleton;
+import com.hubspot.blazar.base.ModuleBuild;
+import com.hubspot.blazar.base.RepositoryBuild;
+
+@Singleton
+public class CachingMetricsService {
+  private static final long MODULE_BUILD_COUNT_MAX_AGE_MILLIS = 500;
+  private static final long BRANCH_BUILD_COUNT_MAX_AGE_MILLIS = 500;
+  private final MetricsService metricsService;
+  private Map<ModuleBuild.State, Integer> moduleBuildCountMap;
+  private Map<RepositoryBuild.State, Integer> repoBuildCountMap;
+  private long moduleBuildCountMapLastWrite;
+  private long repoBuildCountMapLastWrite;
+
+  @Inject
+  public CachingMetricsService(MetricsService metricsService) {
+    this.metricsService = metricsService;
+    this.moduleBuildCountMap = new HashMap<>();
+    this.moduleBuildCountMapLastWrite = 0;
+    this.repoBuildCountMapLastWrite = 0;
+  }
+
+  public Integer getCachedActiveModuleBuildCountByState(ModuleBuild.State state) {
+    long currentTime = System.currentTimeMillis();
+    if (currentTime - moduleBuildCountMapLastWrite > MODULE_BUILD_COUNT_MAX_AGE_MILLIS) {
+      // refresh cache
+      moduleBuildCountMap = metricsService.countActiveModuleBuildsByState();
+    }
+
+    if (!moduleBuildCountMap.containsKey(state)) {
+      return 0;
+    }
+    return moduleBuildCountMap.get(state);
+  }
+
+  public Integer getCachedActiveBranchBuildCountByState(RepositoryBuild.State state) {
+    long currentTime = System.currentTimeMillis();
+    if (currentTime - repoBuildCountMapLastWrite > BRANCH_BUILD_COUNT_MAX_AGE_MILLIS) {
+      repoBuildCountMap = metricsService.countActiveBranchBuildsByState();
+    }
+
+    if (!repoBuildCountMap.containsKey(state)) {
+      return 0;
+    }
+
+    return repoBuildCountMap.get(state);
+  }
+}

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/service/MetricsService.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/service/MetricsService.java
@@ -1,0 +1,39 @@
+package com.hubspot.blazar.data.service;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import com.google.inject.Inject;
+import com.hubspot.blazar.base.ModuleBuild;
+import com.hubspot.blazar.base.RepositoryBuild;
+import com.hubspot.blazar.base.metrics.StateToActiveBuildCountPair;
+import com.hubspot.blazar.data.dao.MetricsDao;
+
+public class MetricsService {
+
+  private MetricsDao dao;
+
+  @Inject
+  public MetricsService(MetricsDao dao) {
+    this.dao = dao;
+  }
+
+  public Map<ModuleBuild.State, Integer> countActiveModuleBuildsByState() {
+    Set<StateToActiveBuildCountPair> pairs = dao.countActiveModuleBuildsByState();
+    Map<ModuleBuild.State, Integer> stateCountMap = new HashMap<>();
+    for (StateToActiveBuildCountPair pair : pairs) {
+      stateCountMap.put(ModuleBuild.State.valueOf(pair.getStateName()), pair.getCount());
+    }
+    return stateCountMap;
+  }
+
+  public Map<RepositoryBuild.State, Integer> countActiveBranchBuildsByState() {
+    Set<StateToActiveBuildCountPair> pairs = dao.countActiveBranchBuildsByState();
+    Map<RepositoryBuild.State, Integer> stateCountMap = new HashMap<>();
+    for (StateToActiveBuildCountPair pair : pairs) {
+      stateCountMap.put(RepositoryBuild.State.valueOf(pair.getStateName()), pair.getCount());
+    }
+    return stateCountMap;
+  }
+}

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/MetricBuildVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/MetricBuildVisitor.java
@@ -44,13 +44,13 @@ public class MetricBuildVisitor implements ModuleBuildVisitor, RepositoryBuildVi
 
     for (ModuleBuild.State state : ModuleBuild.State.values()) {
       if (state.isRunning() || state.isWaiting()) {
-        metricRegistry.register((state.getClass().getCanonicalName() + "." + state.toString() + ".count").toLowerCase(), buildModuleStateGuage(state));
+        metricRegistry.register((state.getClass().getCanonicalName() + "." + state.toString() + ".count"), buildModuleStateGuage(state));
       }
     }
 
     for (RepositoryBuild.State state : RepositoryBuild.State.values()) {
       if (!state.isComplete()) {
-        metricRegistry.register((state.getClass().getCanonicalName() + "." + state.toString() + ".count").toLowerCase(), buildBranchStateGuage(state));
+        metricRegistry.register((state.getClass().getCanonicalName() + "." + state.toString() + ".count"), buildBranchStateGuage(state));
       }
     }
   }

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/MetricBuildVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/MetricBuildVisitor.java
@@ -1,5 +1,6 @@
 package com.hubspot.blazar.listener;
 
+import com.codahale.metrics.Gauge;
 import com.codahale.metrics.Meter;
 import com.codahale.metrics.MetricRegistry;
 import com.google.inject.Inject;
@@ -8,37 +9,57 @@ import com.hubspot.blazar.base.ModuleBuild;
 import com.hubspot.blazar.base.RepositoryBuild;
 import com.hubspot.blazar.base.visitor.ModuleBuildVisitor;
 import com.hubspot.blazar.base.visitor.RepositoryBuildVisitor;
+import com.hubspot.blazar.data.service.CachingMetricsService;
 import com.hubspot.blazar.util.SingularityBuildWatcher;
 
 @Singleton
 public class MetricBuildVisitor implements ModuleBuildVisitor, RepositoryBuildVisitor {
 
   private final MetricRegistry metricRegistry;
+  private CachingMetricsService cachingMetricsService;
 
   @Inject
-  public MetricBuildVisitor(MetricRegistry metricRegistry){
+  public MetricBuildVisitor(MetricRegistry metricRegistry,
+                            CachingMetricsService cachingMetricsService){
     this.metricRegistry = metricRegistry;
-    for (ModuleBuild.State state : ModuleBuild.State.values()) {
-      metricRegistry.register(makeMetricName(ModuleBuild.class, state), new Meter());
-    }
-    for (RepositoryBuild.State state : RepositoryBuild.State.values()) {
-      metricRegistry.register(makeMetricName(RepositoryBuild.class, state), new Meter());
-    }
+    this.cachingMetricsService = cachingMetricsService;
     // Ensures that there always are meters for these since they're important to alert on
     metricRegistry.register(SingularityBuildWatcher.class.getName() + ".succeeded", new Meter());
     metricRegistry.register(SingularityBuildWatcher.class.getName() + ".failed", new Meter());
+    registerActiveBuildStateGauges();
   }
 
   public void visit(ModuleBuild moduleBuild) {
-    metricRegistry.meter(makeMetricName(ModuleBuild.class, moduleBuild.getState())).mark();
   }
 
   public void visit(RepositoryBuild repositoryBuild) {
-    metricRegistry.meter(makeMetricName(RepositoryBuild.class, repositoryBuild.getState())).mark();
   }
 
 
   private static String makeMetricName(Class<?> buildClass, Enum<?> state) {
     return buildClass.getName() + "." + state.name();
+  }
+
+  private void registerActiveBuildStateGauges() {
+
+    for (ModuleBuild.State state : ModuleBuild.State.values()) {
+      if (state.isRunning() || state.isWaiting()) {
+        metricRegistry.register((state.getClass().getCanonicalName() + "." + state.toString() + ".count").toLowerCase(), buildModuleStateGuage(state));
+      }
+    }
+
+    for (RepositoryBuild.State state : RepositoryBuild.State.values()) {
+      if (!state.isComplete()) {
+        metricRegistry.register((state.getClass().getCanonicalName() + "." + state.toString() + ".count").toLowerCase(), buildBranchStateGuage(state));
+      }
+    }
+  }
+
+  private Gauge<Number> buildBranchStateGuage(RepositoryBuild.State state) {
+    return () -> cachingMetricsService.getCachedActiveBranchBuildCountByState(state);
+  }
+
+  private Gauge<Number> buildModuleStateGuage(ModuleBuild.State state) {
+    return () -> cachingMetricsService.getCachedActiveModuleBuildCountByState(state);
   }
 }

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackImNotificationVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackImNotificationVisitor.java
@@ -61,10 +61,10 @@ public class SlackImNotificationVisitor implements RepositoryBuildVisitor {
   private void sendSlackMessageWithRetries(RepositoryBuild build, SlackAttachment attachment) {
     try {
       SlackUtils.makeSlackMessageSendingRetryer().call(() -> sendSlackMessage(build, attachment));
-      metricRegistry.counter("successful-slack-dm-sends").inc();
+      metricRegistry.meter("successful-slack-dm-sends").mark();
     } catch (Exception e){
       LOG.error("Could not send slack message {}", attachment, e);
-      metricRegistry.counter("failed-slack-dm-sends").inc();
+      metricRegistry.meter("failed-slack-dm-sends").mark();
     }
   }
 

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackRoomNotificationVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackRoomNotificationVisitor.java
@@ -85,9 +85,9 @@ public class SlackRoomNotificationVisitor implements RepositoryBuildVisitor, Mod
   private void sendSlackMessageWithRetries(String channelName, SlackAttachment attachment) {
     try {
       SlackUtils.makeSlackMessageSendingRetryer().call(() -> sendSlackMessage(channelName, attachment));
-      metricRegistry.counter("successful-slack-channel-sends").inc();
+      metricRegistry.meter("successful-slack-channel-sends").mark();
     } catch (Exception e) {
-      metricRegistry.counter("failed-slack-channel-sends").inc();
+      metricRegistry.meter("failed-slack-channel-sends").mark();
       LOG.error("Could not send slack message {}", attachment, e);
     }
   }


### PR DESCRIPTION
@gchomatas
This PR adds guages to track the current count of builds at each non-terminal state at both the repo and module level.

I know we discussed tracking the _time_ between Queue - Launching - Running but I think that is best handled separately because it will require a lot of context propagation since currently we have no timestamp information to go off of at any point where that state changes, I'll work on handling that separately.