### PR TITLE
Log upstream module builds state before launching

### DIFF
--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectModuleBuildVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectModuleBuildVisitor.java
@@ -117,7 +117,6 @@ public class InterProjectModuleBuildVisitor extends AbstractModuleBuildVisitor {
   private boolean shouldBuild(int moduleId, int branchId, DependencyGraph graph, Set<InterProjectBuildMapping> mappings) {
     // don't start builds of modules previously triggered
     if (mappings.stream().filter((InterProjectBuildMapping m) -> m.getModuleId() == moduleId).findFirst().isPresent()) {
-      LOG.info("Not staring dependency build for module {} on branch {} because one already is started", moduleId, branchId);
       return false;
     }
     for (Integer upstream: graph.getAllUpstreamNodes(moduleId)) {

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectModuleBuildVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectModuleBuildVisitor.java
@@ -117,6 +117,7 @@ public class InterProjectModuleBuildVisitor extends AbstractModuleBuildVisitor {
   private boolean shouldBuild(int moduleId, int branchId, DependencyGraph graph, Set<InterProjectBuildMapping> mappings) {
     // don't start builds of modules previously triggered
     if (mappings.stream().filter((InterProjectBuildMapping m) -> m.getModuleId() == moduleId).findFirst().isPresent()) {
+      LOG.info("Not staring dependency build for module {} on branch {} because one already is started", moduleId, branchId);
       return false;
     }
     for (Integer upstream: graph.getAllUpstreamNodes(moduleId)) {

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/QueuedModuleBuildVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/QueuedModuleBuildVisitor.java
@@ -69,7 +69,7 @@ public class QueuedModuleBuildVisitor extends AbstractModuleBuildVisitor {
 
       if (buildingUpstreams.isEmpty()) {
         LOG.info("{} is no longer waiting for upstreams and is ready to build", buildingStatusLogPrefix);
-        return buildingUpstreams.isEmpty();
+        return true;
       }
 
       Set<Long> runningUpstreamModuleBuildIds = new HashSet<>();


### PR DESCRIPTION
A few builds are hanging waiting for upstreams to be complete
before the rest of the build completes, this adds logging to the
code that makes the decision whether to launch the next module.

@gchomatas 