### PR TITLE
Redirect beta users to new branch state page

### DIFF
--- a/BlazarUI/app/index.mustache
+++ b/BlazarUI/app/index.mustache
@@ -49,6 +49,7 @@
         offsetLength: {{{offsetLength}}},
         {{#apiRoot}}apiRoot: "{{{apiRoot}}}",{{/apiRoot}}
         {{#usernameCookie}}usernameCookie: "{{{usernameCookie}}}",{{/usernameCookie}}
+        {{#betaUserCookie}}betaUserCookie: "{{{betaUserCookie}}}",{{/betaUserCookie}}
         {{#slackBotName}}slackBotName: "{{{slackBotName}}}",{{/slackBotName}}
         {{#heapToken}}heapToken: "{{{heapToken}}}",{{/heapToken}}
       }

--- a/BlazarUI/app/scripts/components/branch-state/BetaFeatureAlert.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/BetaFeatureAlert.jsx
@@ -1,0 +1,20 @@
+import React, { PropTypes } from 'react';
+import Alert from 'react-bootstrap/lib/Alert';
+
+import {Link} from 'react-router';
+
+const BetaFeatureAlert = ({branchId}) => {
+  return (
+    <Alert bsStyle="info">
+      <h4>Beta - tell us what you think!</h4>
+      <p>Hey! You're seeing this new page because you’re  part of the Blazar beta group. We'd love to hear any feedback you have using the link at the bottom of this page.</p>
+      <p><Link to={`/branches/${branchId}/builds`}>Return to the previous design</Link></p>
+    </Alert>
+  );
+};
+
+BetaFeatureAlert.propTypes = {
+  branchId: PropTypes.number.isRequired,
+};
+
+export default BetaFeatureAlert;

--- a/BlazarUI/app/scripts/components/branch-state/BetaFeatureAlert.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/BetaFeatureAlert.jsx
@@ -7,8 +7,9 @@ const BetaFeatureAlert = ({branchId}) => {
   return (
     <Alert bsStyle="info">
       <h4>Beta - tell us what you think!</h4>
-      <p>Hey! You're seeing this new page because you’re  part of the Blazar beta group. We'd love to hear any feedback you have using the link at the bottom of this page.</p>
-      <p><Link to={`/branches/${branchId}/builds`}>Return to the previous design</Link></p>
+      <p>Hey! Your team has been selected as part of the initial rollout of the new Module-Centric builds page. This page will provide you with a more informative view of the current state of a branch and will eventually become the main page for accessing your builds in the future.</p>
+      <p>We'd love to hear any feedback you have using the link at the bottom of this page.</p>
+      <p className="build-history-link"><Link to={`/branches/${branchId}/builds`}>Return to branch build history page</Link></p>
     </Alert>
   );
 };

--- a/BlazarUI/app/scripts/components/branch-state/BranchState.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/BranchState.jsx
@@ -8,6 +8,7 @@ import GenericErrorMessage from '../shared/GenericErrorMessage.jsx';
 import Loader from '../shared/Loader.jsx';
 import ModuleList from './ModuleList.jsx';
 import BranchStateHeadline from './BranchStateHeadline.jsx';
+import BetaFeatureAlert from './BetaFeatureAlert.jsx';
 import BuildBranchModalContainer from '../shared/BuildBranchModalContainer.jsx';
 import FailingModuleBuildsAlert from './FailingModuleBuildsAlert.jsx';
 
@@ -90,13 +91,19 @@ class BranchState extends Component {
   }
 
   renderModuleLists() {
-    const {loadingModuleStates, activeModules, inactiveModules, selectedModuleId} = this.props;
-    if (loadingModuleStates) {
+    const {loadingModuleStates, activeModules, inactiveModules, selectedModuleId, branchId} = this.props;
+    const loadingHeader = !this.props.branchInfo.branch;
+    if (loadingModuleStates || loadingHeader) {
       return <Loader />;
     }
 
+    const failingModuleNames = this.getFailingModuleNames(activeModules);
+    const hasFailingModules = !!failingModuleNames.size;
+
     return (
       <div>
+        <BetaFeatureAlert branchId={branchId} />
+        {hasFailingModules && <FailingModuleBuildsAlert failingModuleNames={failingModuleNames} />}
         <section id="active-modules">
           <h2 className="module-list-header">Active modules</h2>
           <ModuleList modules={this.sortActiveModules(activeModules)} onItemClick={this.handleModuleItemClick} selectedModuleId={selectedModuleId} />
@@ -128,13 +135,9 @@ class BranchState extends Component {
       );
     }
 
-    const failingModuleNames = this.getFailingModuleNames(activeModules);
-    const hasFailingModules = !!failingModuleNames.size;
-
     return (
       <PageContainer classNames="page-content--branch-state" documentTitle={title}>
         <BranchStateHeadline branchId={branchId} branchInfo={branchInfo} onBranchSelect={this.handleBranchSelect} />
-        {hasFailingModules && <FailingModuleBuildsAlert failingModuleNames={failingModuleNames} />}
         {this.renderModuleLists()}
         <BuildBranchModalContainer
           branchId={branchId}

--- a/BlazarUI/app/scripts/components/branch/BranchHeadline.jsx
+++ b/BlazarUI/app/scripts/components/branch/BranchHeadline.jsx
@@ -44,7 +44,10 @@ class BranchHeadline extends Component {
     }
 
     const branchLink = `/builds/branch/${selected}`;
-    this.context.router.push(branchLink);
+    this.context.router.push({
+      pathname: branchLink,
+      state: {handlingBranchSelect: true}
+    });
   }
 
   getFilteredBranches() {

--- a/BlazarUI/app/scripts/routes.js
+++ b/BlazarUI/app/scripts/routes.js
@@ -14,6 +14,8 @@ import RepoBuild from './pages/repoBuild.jsx';
 import NotFound from './pages/notFound.jsx';
 import BranchState from './components/branch-state/BranchStateContainer.jsx';
 
+import { isBetaUser } from './utils/user.js';
+
 function redirectRepoBuildShortlink(nextState, replace, callback) {
   const data = $.ajax({
     url: `${window.config.apiRoot}/branches/builds/${nextState.params.repoBuildId}`,
@@ -30,17 +32,27 @@ function redirectRepoBuildShortlink(nextState, replace, callback) {
   });
 }
 
+function redirectBetaUsersToBranchStatePage(nextState, replace) {
+  const locationState = nextState.location.state || {};
+  if (isBetaUser && !locationState.handlingBranchSelect) {
+    replace(`/branches/${nextState.params.branchId}/state`);
+  }
+}
+
 const routes = (
   <Route name="app" path="/" component={App}>
     <IndexRoute name="dashboard" component={ Dashboard } />
     <Route name="host" path="/builds/org/:org" component={ Org } />
     <Route name="repo" path="/builds/repo/:repo" component={ Repo } />
-    <Route name="branch" path="/builds/branch/:branchId" component={ Branch } />
+    <Route name="branch" path="/builds/branch/:branchId" component={ Branch } onEnter={redirectBetaUsersToBranchStatePage} />
     <Route name="settings" path="/settings/branch/:branchId" component={ Settings } />
     <Route name="repoBuild" path="/builds/branch/:branchId/build/:buildNumber" component={ RepoBuild } />
     <Route name="build" path="/builds/branch/:branchId/build/:buildNumber/module/:moduleName" component={ Build } />
     <Route name="repoBuildShortlink" path="/builds/repo-build/:repoBuildId" onEnter={redirectRepoBuildShortlink} />
+
     <Route name="branchState" path="/branches/:branchId/state" component= { BranchState } />
+    <Route name="branchBuildHistory" path="/branches/:branchId/builds" component= { Branch } />
+
     <Route name="notFound" path="*" component={ NotFound } />
   </Route>
 );

--- a/BlazarUI/app/scripts/utils/user.js
+++ b/BlazarUI/app/scripts/utils/user.js
@@ -1,3 +1,5 @@
-import store from 'store';
+import Cookies from 'js-cookie';
 
-export const isBetaUser = store.get('blazar-beta');
+const { betaUserCookie } = window.config;
+
+export const isBetaUser = betaUserCookie && !!Cookies.get(betaUserCookie);

--- a/BlazarUI/app/scripts/utils/user.js
+++ b/BlazarUI/app/scripts/utils/user.js
@@ -1,0 +1,3 @@
+import store from 'store';
+
+export const isBetaUser = store.get('blazar-beta');

--- a/BlazarUI/app/stylus/page/branch-state.styl
+++ b/BlazarUI/app/stylus/page/branch-state.styl
@@ -78,3 +78,6 @@
   list-style none
   padding-left 20px
   margin-bottom 0
+
+.alert .build-history-link
+  margin-top 10px

--- a/BlazarUI/app/stylus/type.styl
+++ b/BlazarUI/app/stylus/type.styl
@@ -19,6 +19,9 @@
 h1, h2, h3, h4, h5, h6
   font-weight $font-light
 
+.alert h4
+  font-weight $font-medium
+
 a
   letter-spacing .02em
   cursor pointer

--- a/BlazarUI/appConfig.js
+++ b/BlazarUI/appConfig.js
@@ -28,6 +28,8 @@ const appConfig = {
 
   usernameCookie: process.env.BLAZAR_USERNAME_COOKIE || '',
 
+  betaUserCookie: process.env.BLAZAR_BETA_USER_COOKIE || '',
+
   slackBotName: process.env.SLACK_BOT_NAME || '',
 
   heapToken: process.env.HEAP_TOKEN || false


### PR DESCRIPTION
For beta users, this will redirect all links to the old branch build history page to the new module centric branch state page. The page now contains a link that will allow users to return to the old page, hosted at a different path, and asks the user for feedback.

<img width="1100" alt="screen shot 2016-10-05 at 4 58 16 pm" src="https://cloud.githubusercontent.com/assets/4141884/19132213/8c5d0c76-8b20-11e6-9c6d-3a28c43a7aa4.png">

Currently the flag for whether or not a user is a beta user is determined by looking up a variable in local storage. I'll need to work with @jonathanwgoodwin to determine a way of injecting some code in for our specific environment.

@gchomatas @markhazlewood 
