### PR TITLE
Fail empty branch builds

### DIFF
--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/GitInfo.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/GitInfo.java
@@ -83,12 +83,92 @@ public class GitInfo {
     return getOrganization() + '/' + getRepository();
   }
 
-  public GitInfo withId(int id) {
-    return new GitInfo(Optional.of(id), host, organization, repository, repositoryId, branch, active, createdTimestamp, updatedTimestamp);
+  public Builder toBuilder() {
+    return new Builder(this);
   }
 
-  public GitInfo withBranch(String branch) {
-    return new GitInfo(id, host, organization, repository, repositoryId, branch, active, createdTimestamp, updatedTimestamp);
+  public class Builder {
+    private Optional<Integer> id;
+    private String host;
+    private String organization;
+    private String repository;
+    private int repositoryId;
+    private String branch;
+    private boolean active;
+    private long createdTimestamp;
+    private long updatedTimestamp;
+
+    public Builder() {
+      this.id = Optional.absent();
+      this.host = "";
+      this.organization = "";
+      this.repository = "";
+      this.repositoryId = 0;
+      this.active = true;
+      this.createdTimestamp = System.currentTimeMillis();
+      this.updatedTimestamp = System.currentTimeMillis();
+    }
+
+    private Builder(GitInfo gitInfo) {
+      id = gitInfo.getId();
+      host = gitInfo.getHost();
+      organization = gitInfo.getOrganization();
+      repository = gitInfo.getRepository();
+      repositoryId = gitInfo.getRepositoryId();
+      branch = gitInfo.getBranch();
+      active = gitInfo.isActive();
+      createdTimestamp = gitInfo.getCreatedTimestamp();
+      updatedTimestamp = gitInfo.getUpdatedTimestamp();
+    }
+
+    public Builder setId(Optional<Integer> id) {
+      this.id = id;
+      return this;
+    }
+
+    public Builder setHost(String host) {
+      this.host = host;
+      return this;
+    }
+
+    public Builder setOrganization(String organization) {
+      this.organization = organization;
+      return this;
+    }
+
+    public Builder setRepository(String repository) {
+      this.repository = repository;
+      return this;
+    }
+
+    public Builder setRepositoryId(int repositoryId) {
+      this.repositoryId = repositoryId;
+      return this;
+    }
+
+    public Builder setBranch(String branch) {
+      this.branch = branch;
+      return this;
+    }
+
+    public Builder setActive(boolean active) {
+      this.active = active;
+      return this;
+    }
+
+    public Builder setCreatedTimestamp(long createdTimestamp) {
+      this.createdTimestamp = createdTimestamp;
+      return this;
+    }
+
+    public Builder setUpdatedTimestamp(long updatedTimestamp) {
+      this.updatedTimestamp = updatedTimestamp;
+      return this;
+    }
+
+    public GitInfo build() {
+      return new GitInfo(id, host, organization, repository, repositoryId, branch, active, createdTimestamp, updatedTimestamp);
+    }
   }
 
   @Override

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/service/BranchService.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/service/BranchService.java
@@ -47,7 +47,7 @@ public class BranchService {
   public GitInfo upsert(GitInfo gitInfo) {
     Optional<GitInfo> existing = getByRepositoryAndBranch(gitInfo.getRepositoryId(), gitInfo.getBranch());
     if (existing.isPresent()) {
-      gitInfo = gitInfo.withId(existing.get().getId().get());
+      gitInfo = gitInfo.toBuilder().setId(Optional.of(existing.get().getId().get())).build();
 
       if (!existing.get().equals(gitInfo)) {
         int updated = branchDao.update(gitInfo);
@@ -58,7 +58,7 @@ public class BranchService {
     } else {
       try {
         int id = branchDao.insert(gitInfo);
-        return gitInfo.withId(id);
+        return gitInfo.toBuilder().setId(Optional.of(id)).build();
       } catch (UnableToExecuteStatementException e) {
         if (e.getCause() instanceof SQLIntegrityConstraintViolationException) {
           return getByRepositoryAndBranch(gitInfo.getRepositoryId(), gitInfo.getBranch()).get();

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/LaunchingRepositoryBuildVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/LaunchingRepositoryBuildVisitor.java
@@ -99,8 +99,8 @@ public class LaunchingRepositoryBuildVisitor extends AbstractRepositoryBuildVisi
     Set<Module> skipped = Sets.difference(modules, toBuild);
 
     if (modules.isEmpty()) {
-      LOG.info("No module builds for repository build {}, setting status to success", build.getId().get());
-      repositoryBuildService.update(build.withState(State.SUCCEEDED).withEndTimestamp(System.currentTimeMillis()));
+      LOG.info("No module builds for repository build {}, setting status to failed", build.getId().get());
+      repositoryBuildService.update(build.withState(State.FAILED).withEndTimestamp(System.currentTimeMillis()));
     } else {
       for (Module module : toBuild) {
         moduleBuildService.enqueue(build, module);

--- a/BlazarService/src/main/java/com/hubspot/blazar/util/GitHubWebhookHandler.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/util/GitHubWebhookHandler.java
@@ -112,7 +112,8 @@ public class GitHubWebhookHandler {
         return;
       }
       if (!isOptedIn(gitInfo)) {
-        LOG.debug("Not {}#{} is not opted in to Blazar", gitInfo.getFullRepositoryName(), gitInfo.getBranch());
+        LOG.info("{}#{} is not opted in to Blazar, marking as inactive", gitInfo.getFullRepositoryName(), gitInfo.getBranch());
+        branchService.upsert(gitInfo.toBuilder().setActive(false).build());
         return;
       }
       gitInfo = branchService.upsert(gitInfo);

--- a/BlazarService/src/main/java/com/hubspot/blazar/util/ModuleBuildLauncher.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/util/ModuleBuildLauncher.java
@@ -59,7 +59,7 @@ public class ModuleBuildLauncher {
   }
 
   public void launch(RepositoryBuild repositoryBuild, ModuleBuild build) throws Exception {
-    GitInfo gitInfo = branchService.get(repositoryBuild.getBranchId()).get().withBranch(repositoryBuild.getSha().get());
+    GitInfo gitInfo = branchService.get(repositoryBuild.getBranchId()).get().toBuilder().setBranch(repositoryBuild.getSha().get()).build();
     Module module = moduleService.get(build.getModuleId()).get();
 
     BuildConfig buildConfig = configAtSha(gitInfo, module);


### PR DESCRIPTION
Builds without modules are "technically" successful in taking no
action. This is usually due to no modules being picked up by discovery
due to malformed files etc. It is confusing for maintainers and developers
to see something that did not take the expected action to terminate
successfully. This change fails branch builds that have not built anything
to be considered a failure.
