### PR TITLE
Sort and group modules by build number

### DIFF
--- a/BlazarUI/app/scripts/components/branch-state/ModuleList.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/ModuleList.jsx
@@ -5,26 +5,37 @@ import Card from '../shared/card-stack/Card.jsx';
 
 import ModuleItem from './ModuleItem.jsx';
 import ModuleBuildHistory from './module-build-history/ModuleBuildHistory.jsx';
+import { getCurrentModuleBuild } from '../Helpers';
 
 const ModuleList = ({modules, onItemClick, selectedModuleId}) => {
+  const modulesGroupedByCurrentBuild = modules.groupBy((moduleState) =>
+    getCurrentModuleBuild(moduleState).get('buildNumber'));
+
   return (
-    <CardStack>
-      {modules.map(moduleState => {
-        const id = moduleState.getIn(['module', 'id']);
-        const moduleName = moduleState.getIn(['module', 'name']);
-        const summary = <ModuleItem moduleState={moduleState} onClick={() => onItemClick(id)} />;
-        const details = <ModuleBuildHistory moduleName={moduleName} moduleId={id} />;
-        const isSelected = selectedModuleId === id;
-        return (
-          <Card
-            key={id}
-            summary={summary}
-            details={details}
-            expanded={isSelected}
-          />
-        );
-      })}
-    </CardStack>
+    <div>
+      {modulesGroupedByCurrentBuild.map((moduleStates, buildNumber) =>
+        <div className="module-list-group" key={buildNumber}>
+          <h3 className="module-list-group__header">Build #{buildNumber}</h3>
+          <CardStack key={buildNumber}>
+            {moduleStates.map(moduleState => {
+              const id = moduleState.getIn(['module', 'id']);
+              const moduleName = moduleState.getIn(['module', 'name']);
+              const summary = <ModuleItem moduleState={moduleState} onClick={() => onItemClick(id)} />;
+              const details = <ModuleBuildHistory moduleName={moduleName} moduleId={id} />;
+              const isSelected = selectedModuleId === id;
+              return (
+                <Card
+                  key={id}
+                  summary={summary}
+                  details={details}
+                  expanded={isSelected}
+                />
+              );
+            })}
+          </CardStack>
+        </div>
+      ).toArray()}
+    </div>
   );
 };
 

--- a/BlazarUI/app/stylus/page/branch-state.styl
+++ b/BlazarUI/app/stylus/page/branch-state.styl
@@ -85,3 +85,11 @@
 
   a
     text-decoration none
+
+.module-list-group
+  margin 0 20px
+
+.module-list-group__header
+  font-weight 400
+  font-size 20px
+


### PR DESCRIPTION
This new sort order brings more recent builds to the top of branch state page and groups related builds closer together.

The build number is used to separate out the grouped builds. In the future, we will move some of the common build information into the headers of the grouped builds.

<img width="1136" alt="screen shot 2016-10-05 at 5 34 30 pm" src="https://cloud.githubusercontent.com/assets/4141884/19132741/07a7e0e8-8b23-11e6-9cde-9ddd1f889531.png">

@gchomatas @markhazlewood @jonathanwgoodwin 
