### PR TITLE
Add a logback appender for sentry to Blazar

### DIFF
--- a/BlazarService/pom.xml
+++ b/BlazarService/pom.xml
@@ -83,6 +83,22 @@
       <groupId>net.sourceforge.argparse4j</groupId>
       <artifactId>argparse4j</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.getsentry.raven</groupId>
+      <artifactId>raven-logback</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-classic</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>ch.qos.logback</groupId>
+      <artifactId>logback-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.dropwizard</groupId>
+      <artifactId>dropwizard-logging</artifactId>
+    </dependency>
     <!-- for jade and jets3t -->
     <dependency>
       <groupId>org.slf4j</groupId>

--- a/BlazarService/src/main/java/com/hubspot/blazar/config/SentryAppenderFactory.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/SentryAppenderFactory.java
@@ -43,24 +43,24 @@ import io.dropwizard.logging.layout.LayoutFactory;
 public class SentryAppenderFactory extends AbstractAppenderFactory<ILoggingEvent> {
   private static final String APPENDER_NAME = "sentry-appender";
   private final String sentryDsn;
-  private final String sentryRelease;
+  private final String blazarRelease;
 
   @JsonCreator
   public SentryAppenderFactory(
       @NotNull
       @JsonProperty("sentryDsn") String sentryDsn,
-      @JsonProperty("sentryRelease") String sentryRelease ) {
+      @JsonProperty("blazarRelease") String blazarRelease ) {
 
     this.sentryDsn = sentryDsn;
-    this.sentryRelease = sentryRelease;
+    this.blazarRelease = blazarRelease;
   }
 
   public String getSentryDsn() {
     return sentryDsn;
   }
 
-  public String getSentryRelease() {
-    return sentryRelease;
+  public String getBlazarRelease() {
+    return blazarRelease;
   }
 
   @Override
@@ -73,7 +73,7 @@ public class SentryAppenderFactory extends AbstractAppenderFactory<ILoggingEvent
     final SentryAppender appender = new SentryAppender();
     appender.setName(APPENDER_NAME);
     appender.setDsn(sentryDsn);
-    appender.setRelease(sentryRelease);
+    appender.setRelease(blazarRelease);
     appender.setServerName(getHostNameOrTaskId());
     appender.setContext(context);
     appender.addFilter(levelFilterFactory.build(Level.ERROR));

--- a/BlazarService/src/main/java/com/hubspot/blazar/config/SentryAppenderFactory.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/SentryAppenderFactory.java
@@ -1,0 +1,99 @@
+package com.hubspot.blazar.config;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+
+import javax.validation.constraints.NotNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.getsentry.raven.logback.SentryAppender;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.Appender;
+import io.dropwizard.logging.AbstractAppenderFactory;
+import io.dropwizard.logging.async.AsyncAppenderFactory;
+import io.dropwizard.logging.filter.LevelFilterFactory;
+import io.dropwizard.logging.layout.LayoutFactory;
+
+/**
+ * This class configures sentry via a Logback appender the resource
+ * file META-INF/services/io.dropwizard.logging.AppenderFactory is responsible
+ * for telling Dropwizard's logging mechanics to create an appender using this class
+ * provided that the logging configuration of type "sentry" is available.
+ *
+ * <p>
+ * sentryDsn: string (Data Source Name) is the secret Sentry gives you to report exceptions with.
+ * sentryRelease: string the version of blazar you are deploying. Sentry will tag exceptions using this release value
+ *
+ * This appender is only used if you configure the logging appender in the dropwizard config for sentry as follows:
+ * {@Code
+ *  logging:
+ *    appenders:
+ *      - type: sentry
+ *        sentryDsn: http://some_Sentry_provided_DSN
+ *        sentryRelease: "PROD"
+ * }
+ *
+ */
+@JsonTypeName("sentry")
+public class SentryAppenderFactory extends AbstractAppenderFactory<ILoggingEvent> {
+  private static final String APPENDER_NAME = "sentry-appender";
+  private final String sentryDsn;
+  private final String sentryRelease;
+
+  @JsonCreator
+  public SentryAppenderFactory(
+      @NotNull
+      @JsonProperty("sentryDsn") String sentryDsn,
+      @JsonProperty("sentryRelease") String sentryRelease ) {
+
+    this.sentryDsn = sentryDsn;
+    this.sentryRelease = sentryRelease;
+  }
+
+  public String getSentryDsn() {
+    return sentryDsn;
+  }
+
+  public String getSentryRelease() {
+    return sentryRelease;
+  }
+
+  @Override
+  public Appender<ILoggingEvent> build(LoggerContext context,
+                                       String applicationName,
+                                       LayoutFactory<ILoggingEvent> layoutFactory,
+                                       LevelFilterFactory<ILoggingEvent> levelFilterFactory,
+                                       AsyncAppenderFactory<ILoggingEvent> asyncAppenderFactory) {
+
+    final SentryAppender appender = new SentryAppender();
+    appender.setName(APPENDER_NAME);
+    appender.setDsn(sentryDsn);
+    appender.setRelease(sentryRelease);
+    appender.setServerName(getHostNameOrTaskId());
+    appender.setContext(context);
+    appender.addFilter(levelFilterFactory.build(Level.ERROR));
+    getFilterFactories().stream().forEach(f -> appender.addFilter(f.build()));
+    appender.start();
+    return wrapAsync(appender, asyncAppenderFactory, context);
+  }
+
+  private static String getHostNameOrTaskId() {
+    // Try to use "TASK_HOST" provided by singularity deploy environment
+    if (System.getenv().containsKey("TASK_HOST") ) {
+      return System.getenv().get("TASK_HOST");
+    }
+
+    // If not deployed in singularity try to fetch the hostname out of dns
+    try {
+      return InetAddress.getLocalHost().getHostName();
+    } catch (UnknownHostException e) {
+      return "unknown-host";
+    }
+  }
+
+}

--- a/BlazarService/src/main/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
+++ b/BlazarService/src/main/resources/META-INF/services/io.dropwizard.logging.AppenderFactory
@@ -1,0 +1,1 @@
+com.hubspot.blazar.config.SentryAppenderFactory

--- a/pom.xml
+++ b/pom.xml
@@ -236,6 +236,26 @@
         <artifactId>javassist</artifactId>
         <version>3.19.0-GA</version>
       </dependency>
+      <dependency>
+        <groupId>com.getsentry.raven</groupId>
+        <artifactId>raven-logback</artifactId>
+        <version>7.2.3</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-classic</artifactId>
+        <version>${dep.logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.logback</groupId>
+        <artifactId>logback-core</artifactId>
+        <version>${dep.logback.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.dropwizard</groupId>
+        <artifactId>dropwizard-logging</artifactId>
+        <version>${dropwizard.version}</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 


### PR DESCRIPTION
cc: @gchomatas 

This appender is only used if you configure the logging appender for sentry as follows:

``` yaml
logging:
  appenders:
  - type: sentry
    sentryDsn: <Sentry provided DSN>
    sentryRelease: "QA"
```
