### PR TITLE
Show commits in branch state page

### DIFF
--- a/BlazarUI/app/scripts/components/Helpers.js
+++ b/BlazarUI/app/scripts/components/Helpers.js
@@ -48,11 +48,10 @@ export const humanizeText = (string) => {
 
 export const truncate = (str, len = 10, ellip = false) => {
   if (str && str.length > len && str.length > 0) {
-    let newStr = `${str} `;
-    newStr = str.substr(0, len);
-    newStr = str.substr(0, newStr.lastIndexOf(' '));
+    const lastSpaceBeforeLimitIndex = str.lastIndexOf(' ', len - 1);
+    let newStr = str.substr(0, lastSpaceBeforeLimitIndex);
     newStr = (newStr.length > 0) ? newStr : str.substr(0, len);
-    if (ellip && str.length > len) {
+    if (ellip) {
       newStr += '…';
     }
     return newStr;

--- a/BlazarUI/app/scripts/components/branch-state/BranchBuildHeader.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/BranchBuildHeader.jsx
@@ -5,11 +5,13 @@ import BuildTriggerLabel from './shared/BuildTriggerLabel.jsx';
 import UsersForBuild from './shared/UsersForBuild.jsx';
 import CommitInfo from './shared/CommitInfo.jsx';
 import CancelBuildButton from '../shared/branch-build/CancelBuildButton.jsx';
+import CommitsSummary from './shared/CommitsSummary.jsx';
 
-const ModuleList = ({branchBuild, onCancelBuild}) => {
+const BranchBuildHeader = ({branchBuild, onCancelBuild}) => {
   const buildNumber = branchBuild.get('buildNumber');
   const buildTrigger = branchBuild.get('buildTrigger');
   const commitInfo = branchBuild.get('commitInfo');
+  const buildId = branchBuild.get('id');
 
   return (
     <div className="branch-build-header">
@@ -20,6 +22,7 @@ const ModuleList = ({branchBuild, onCancelBuild}) => {
         <BuildTriggerLabel buildTrigger={buildTrigger} />
       </span>
       <UsersForBuild branchBuild={branchBuild} />
+      <CommitsSummary className="branch-build-header__commits" commitInfo={commitInfo} buildId={buildId} />
       <span className="branch-build-header__action-items">
         <CancelBuildButton
           onCancel={onCancelBuild}
@@ -33,7 +36,7 @@ const ModuleList = ({branchBuild, onCancelBuild}) => {
   );
 };
 
-ModuleList.propTypes = {
+BranchBuildHeader.propTypes = {
   branchBuild: ImmutablePropTypes.mapContains({
     buildNumber: PropTypes.number.isRequired,
     buildTrigger: ImmutablePropTypes.map.isRequired,
@@ -42,4 +45,4 @@ ModuleList.propTypes = {
   onCancelBuild: PropTypes.func.isRequired
 };
 
-export default ModuleList;
+export default BranchBuildHeader;

--- a/BlazarUI/app/scripts/components/branch-state/module-build-history/ModuleBuildHistoryItem.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/module-build-history/ModuleBuildHistoryItem.jsx
@@ -7,6 +7,7 @@ import ModuleBuildStatus from '../shared/ModuleBuildStatus.jsx';
 import BuildTriggerLabel from '../shared/BuildTriggerLabel.jsx';
 import CommitInfoLink from '../shared/CommitInfoLink.jsx';
 import UsersForBuild from '../shared/UsersForBuild.jsx';
+import CommitsSummary from '../shared/CommitsSummary.jsx';
 
 import { canViewDetailedModuleBuildInfo, getBlazarModuleBuildPath } from '../../Helpers';
 
@@ -19,6 +20,8 @@ const ModuleBuildHistoryItem = ({moduleBuild, moduleName, branchBuild, router}) 
     onClick = () => {router.push(linkPath);};
   }
 
+  const commitInfo = branchBuild.get('commitInfo');
+
   const classes = classNames('module-build-history-item', {'module-build-history-item--clickable': !!onClick});
   return (
     <li>
@@ -30,10 +33,13 @@ const ModuleBuildHistoryItem = ({moduleBuild, moduleName, branchBuild, router}) 
           <div className="module-build-history-item__users-for-build-wrapper">
             <UsersForBuild branchBuild={branchBuild} />
           </div>
+          <div className="module-build-history-item__commits-wrapper">
+            <CommitsSummary commitInfo={commitInfo} buildId={branchBuild.get('id')} popoverPlacement="left" />
+          </div>
           <div className="module-build-history-item__build-trigger-label">
             <BuildTriggerLabel buildTrigger={branchBuild.get('buildTrigger')} />
           </div>
-          <CommitInfoLink commitInfo={branchBuild.get('commitInfo')} className="module-build-history-item__commit-info" />
+          <CommitInfoLink commitInfo={commitInfo} className="module-build-history-item__commit-info" />
       </div>
     </li>
   );

--- a/BlazarUI/app/scripts/components/branch-state/shared/CommitsSummary.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/shared/CommitsSummary.jsx
@@ -1,0 +1,124 @@
+import React, { Component, PropTypes } from 'react';
+import ReactDOM from 'react-dom';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import Immutable from 'immutable';
+import classNames from 'classnames';
+import {bindAll} from 'underscore';
+
+import Overlay from 'react-bootstrap/lib/Overlay';
+import Popover from 'react-bootstrap/lib/Popover';
+
+import Icon from '../../shared/Icon.jsx';
+import CommitsSummaryPopover from './CommitsSummaryPopover.jsx';
+import { getCompareUrl } from '../../../utils/commitInfoHelpers';
+
+// add some delay to allow scrolling across commits
+// in a table without triggering any popovers
+const DELAY = 200;
+
+class CommitsSummary extends Component {
+  constructor(props) {
+    super(props);
+    this.state = {show: false};
+    bindAll(this, 'delayedShow', 'delayedHide');
+  }
+
+  showPopover() {
+    this.setState({show: true});
+  }
+
+  hidePopover() {
+    this.setState({show: false});
+  }
+
+  delayedShow() {
+    clearTimeout(this.hideDelay);
+    this.hideDelay = null;
+
+    if (!this.showDelay) {
+      this.showDelay = setTimeout(() => {
+        this.showDelay = null;
+        this.showPopover();
+      }, DELAY);
+    }
+  }
+
+  delayedHide() {
+    clearTimeout(this.showDelay);
+    this.showDelay = null;
+
+    if (!this.hideDelay) {
+      this.hideDelay = setTimeout(() => {
+        this.hideDelay = null;
+        this.hidePopover();
+      }, DELAY);
+    }
+  }
+
+  render() {
+    const {commitInfo, className, popoverPlacement, buildId} = this.props;
+    const currentCommit = commitInfo.get('current');
+    const newCommits = commitInfo.get('newCommits');
+
+    const hasNewCommits = !newCommits.isEmpty();
+    const commitList = hasNewCommits ?
+      newCommits.sort((a, b) => b.get('timestamp') - a.get('timestamp')) :
+      Immutable.List.of(currentCommit);
+
+    const compareCommitsUrl = getCompareUrl(commitInfo);
+
+    let text;
+    if (hasNewCommits) {
+      text = (commitList.size === 1) ? '1 commit' : `${commitList.size} commits`;
+    } else {
+      text = 'latest commit';
+    }
+
+    return (
+      <span>
+        <span
+          className={classNames('commits-summary', className)}
+          ref={(ref) => {this.popoverTrigger = ref;}}
+          onMouseEnter={this.delayedShow}
+          onMouseLeave={this.delayedHide}
+        >
+          <Icon type="octicon" name="git-commit" /> {text}
+        </span>
+
+        <Overlay
+          show={this.state.show}
+          placement={popoverPlacement}
+          target={() => ReactDOM.findDOMNode(this.popoverTrigger)}
+        >
+          <Popover
+            ref={(ref) => {this.popover = ref;}}
+            onMouseEnter={this.delayedShow}
+            onMouseLeave={this.delayedHide}
+            id={`commit-summary-popover-${buildId}`}
+          >
+            <CommitsSummaryPopover
+              commitList={commitList}
+              compareCommitsUrl={compareCommitsUrl}
+            />
+          </Popover>
+        </Overlay>
+      </span>
+    );
+  }
+}
+
+CommitsSummary.propTypes = {
+  commitInfo: ImmutablePropTypes.mapContains({
+    current: ImmutablePropTypes.map,
+    newCommits: ImmutablePropTypes.list
+  }),
+  className: PropTypes.string,
+  popoverPlacement: PropTypes.string,
+  buildId: PropTypes.number.isRequired
+};
+
+CommitsSummary.defaultProps = {
+  popoverPlacement: 'bottom'
+};
+
+export default CommitsSummary;

--- a/BlazarUI/app/scripts/components/branch-state/shared/CommitsSummaryPopover.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/shared/CommitsSummaryPopover.jsx
@@ -1,0 +1,103 @@
+import React, { PropTypes } from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
+import classNames from 'classnames';
+
+import Icon from '../../shared/Icon.jsx';
+import Image from '../../shared/Image.jsx';
+import { truncate } from '../../Helpers';
+
+const MAX_COMMITS_DISPLAYED = 5;
+const MAX_DISPLAYED_COMMIT_MESSAGE_LENGTH = 80;
+
+const CommitRowIcon = ({isFirstRow}) => {
+  if (isFirstRow) {
+    return (
+      <div className="commits-summary-poverover__branch-head-icon">
+        <Image src={`${window.config.staticRoot}/images/branch_head.png`} height={25} width={25} />
+      </div>
+    );
+  }
+
+  return (
+    <Icon
+      type="octicon"
+      name="git-commit"
+      classNames="commits-summary-poverover__git-commit-icon"
+    />
+  );
+};
+
+CommitRowIcon.propTypes = {
+  isFirstRow: PropTypes.bool.isRequired
+};
+
+const CommitRow = ({commit, index}) => {
+  const isFirstRow = index === 0;
+  const commitIconClassName = classNames('commits-summary-poverover__commit-icon', {
+    'commits-summary-poverover__commit-icon--first': isFirstRow
+  });
+
+  const commitMessage = commit.get('message');
+  const formattedCommitMessage = truncate(commitMessage, MAX_DISPLAYED_COMMIT_MESSAGE_LENGTH, true);
+
+  return (
+    <tr className="commits-summary-poverover__commit">
+      <td className={commitIconClassName}>
+        <CommitRowIcon isFirstRow={isFirstRow} />
+      </td>
+      <td className="commits-summary-popover__commit-message">
+        <a href={commit.get('url')} target="_blank">{formattedCommitMessage}</a>
+      </td>
+    </tr>
+  );
+};
+
+CommitRow.propTypes = {
+  commit: ImmutablePropTypes.mapContains({
+    message: PropTypes.string.isRequired,
+    url: PropTypes.string.isRequired
+  }),
+  index: PropTypes.number.isRequired
+};
+
+const CommitsSummaryPopover = ({commitList, compareCommitsUrl}) => {
+  const truncateCommits = commitList.size > MAX_COMMITS_DISPLAYED;
+  const displayedCommits = commitList.take(MAX_COMMITS_DISPLAYED);
+  const singleCommit = commitList.size === 1;
+
+  const externalLinkText = truncateCommits ?
+    `View all ${commitList.size} commits` : 'View commits in github';
+
+  const tableClassNames = classNames('commits-summary-popover__commit-list',
+    {'commits-summary-popover__commit-list--single-commit': singleCommit});
+
+  return (
+    <div className="commits-summary-popover">
+      <table className={tableClassNames}>
+        <tbody>
+          {displayedCommits.map((commit, index) =>
+            <CommitRow key={commit.get('id')} commit={commit} index={index} />)
+          }
+        </tbody>
+      </table>
+      {!singleCommit && (
+        <p className="commits-summary-popover__footer">
+          <a
+            className="commits-summary-popover__view-commits-link"
+            href={compareCommitsUrl}
+            target="_blank"
+          >
+            {externalLinkText} <Icon name="external-link" />
+          </a>
+        </p>
+      )}
+    </div>
+  );
+};
+
+CommitsSummaryPopover.propTypes = {
+  commitList: ImmutablePropTypes.list.isRequired,
+  compareCommitsUrl: PropTypes.string.isRequired
+};
+
+export default CommitsSummaryPopover;

--- a/BlazarUI/app/scripts/components/branch-state/shared/CompareCommitsLink.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/shared/CompareCommitsLink.jsx
@@ -1,13 +1,16 @@
 import React, { PropTypes } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import Icon from '../../shared/Icon.jsx';
+import { getCompareUrl } from '../../../utils/commitInfoHelpers';
 
 const CompareCommitsLink = ({commitInfo, className}) => {
-  const previousCommitUrl = commitInfo.getIn(['previous', 'url']);
-  const currentCommitId = commitInfo.getIn(['current', 'id']);
-  const commitUrl = `${previousCommitUrl.replace('/commit/', '/compare/')}...${currentCommitId}`;
   return (
-    <a className={className} href={commitUrl} target="_blank" onClick={(e) => e.stopPropagation()}>
+    <a
+      className={className}
+      href={getCompareUrl(commitInfo)}
+      target="_blank"
+      onClick={(e) => e.stopPropagation()}
+    >
       <Icon type="octicon" name="diff" />
     </a>
   );

--- a/BlazarUI/app/scripts/data/BranchStateApi.js
+++ b/BlazarUI/app/scripts/data/BranchStateApi.js
@@ -15,6 +15,7 @@ function fetchModuleBuildHistory(moduleId, offset, pageSize) {
     'moduleBuildInfos.branchBuild.branchId',
     'moduleBuildInfos.branchBuild.buildTrigger',
     'moduleBuildInfos.branchBuild.commitInfo',
+    'moduleBuildInfos.branchBuild.id',
     'remaining'
   ];
 

--- a/BlazarUI/app/scripts/utils/commitInfoHelpers.js
+++ b/BlazarUI/app/scripts/utils/commitInfoHelpers.js
@@ -1,0 +1,5 @@
+export const getCompareUrl = (commitInfo) => {
+  const previousCommitUrl = commitInfo.getIn(['previous', 'url']);
+  const currentCommitId = commitInfo.getIn(['current', 'id']);
+  return `${previousCommitUrl.replace('/commit/', '/compare/')}...${currentCommitId}`;
+};

--- a/BlazarUI/app/stylus/components/branch-state/branch-build-header.styl
+++ b/BlazarUI/app/stylus/components/branch-state/branch-build-header.styl
@@ -13,6 +13,9 @@
 .branch-build-header__build-trigger-label-wrapper
   margin-right 5px
 
+.branch-build-header__commits
+  margin-left 40px
+
 .branch-build-header__action-items
   float right
   font-weight 500
@@ -29,10 +32,3 @@
   &:hover, &:focus, &[disabled]:hover
     color $color-candy-apple-dark
 
-.commit-info__compare-link
-  margin-left 5px
-  position relative
-  bottom 1px
-
-.commit-link
-  color $color-calypso

--- a/BlazarUI/app/stylus/components/branch-state/commits-summary-popover.styl
+++ b/BlazarUI/app/stylus/components/branch-state/commits-summary-popover.styl
@@ -1,0 +1,52 @@
+@import '../../variables'
+
+.commits-summary-popover
+  max-width 300px
+  font-size 12px
+
+  a
+    color $color-gypsum !important
+
+.commits-summary-popover__commit-list
+  position relative
+  padding-left 14px
+  z-index 0
+
+  &:not(.commits-summary-popover__commit-list--single-commit):before
+    position absolute
+    top 30px
+    bottom 0
+    left 12px
+    width 1px
+    content ""
+    background-color $color-gypsum
+    z-index -1
+
+.commits-summary-poverover__commit-icon
+  width 24px
+  text-align center
+  vertical-align top
+  padding-top 6px
+
+.commits-summary-poverover__commit-icon--first
+  vertical-align middle
+  padding-top 0
+
+.commits-summary-poverover__branch-head-icon
+  padding-bottom 2px
+  background-color $color-heffalump
+
+.commits-summary-poverover__git-commit-icon
+  background-color $color-heffalump
+  line-height 13px
+
+.commits-summary-popover__commit-message
+  padding-left 10px
+  font-style italic
+  padding-top 6px
+  padding-bottom 6px
+
+.commits-summary-popover__footer
+  margin-top 14px
+  margin-bottom 0
+  text-align right

--- a/BlazarUI/app/stylus/components/branch-state/commits.styl
+++ b/BlazarUI/app/stylus/components/branch-state/commits.styl
@@ -1,0 +1,13 @@
+@import '../../variables'
+
+.commits-summary
+  color $color-calypso
+  padding 0 5px
+
+.commit-info__compare-link
+  margin-left 5px
+  position relative
+  bottom 1px
+
+.commit-link
+  color $color-calypso

--- a/BlazarUI/app/stylus/components/branch-state/module-build-history.styl
+++ b/BlazarUI/app/stylus/components/branch-state/module-build-history.styl
@@ -36,10 +36,13 @@
 
 .module-build-history-item__users-for-build-wrapper
   width 30%
-  margin-right 100px
   text-overflow ellipsis
   overflow hidden
   white-space nowrap
+
+.module-build-history-item__commits-wrapper
+  width 20%
+  margin-right 100px
 
 .module-build-history-item__build-trigger-label
   font-size 12px

--- a/BlazarUI/app/stylus/components/branch-state/module-item.styl
+++ b/BlazarUI/app/stylus/components/branch-state/module-item.styl
@@ -13,4 +13,4 @@
   font-size 18px
 
 .module-build-tabs + .module-build
-  padding-left: 29px
+  padding-left 29px

--- a/BlazarUI/app/stylus/main.styl
+++ b/BlazarUI/app/stylus/main.styl
@@ -18,6 +18,8 @@
 @import 'components/alert'
 @import 'components/branch-state/branch-build-header'
 @import 'components/branch-state/build-trigger-label'
+@import 'components/branch-state/commits-summary-popover'
+@import 'components/branch-state/commits'
 @import 'components/branch-state/module-build'
 @import 'components/branch-state/module-build-history'
 @import 'components/branch-state/module-build-number'

--- a/BlazarUI/app/stylus/vendor-overrides/bootstrap-overrides.styl
+++ b/BlazarUI/app/stylus/vendor-overrides/bootstrap-overrides.styl
@@ -6,6 +6,7 @@ $pagination-hover-color ?= $color-calypso
 $pagination-active-color ?= $color-calypso
 $pagination-active-bg ?= $color-calypso-light
 $pagination-hover-bg ?= $color-koala
+$popover-bg ?= $color-heffalump
 
 @import 'bootstrap'
 
@@ -47,3 +48,6 @@ label
   padding-bottom 12px
   padding-top 30px
   color $color-heffalump
+
+.popover-content
+  color $color-gypsum


### PR DESCRIPTION
The placement of this popover is on the left for the module build activity list so that you can actually hover over commits summary for different items.

Multiple commits in branch build header
<img width="289" alt="screen shot 2016-10-18 at 12 39 50 pm" src="https://cloud.githubusercontent.com/assets/4141884/19487313/44678f80-9530-11e6-8f71-41610ff9bf07.png">

More than 5 commits in branch build header
<img width="285" alt="screen shot 2016-10-18 at 12 40 10 pm" src="https://cloud.githubusercontent.com/assets/4141884/19487314/446ea694-9530-11e6-9c77-af73fb6bdf05.png">

Single commit in module activity
<img width="282" alt="screen shot 2016-10-18 at 12 40 27 pm" src="https://cloud.githubusercontent.com/assets/4141884/19487315/446ff396-9530-11e6-8bef-7a65f6581ee4.png">

No new commits in module activity
<img width="406" alt="screen shot 2016-10-18 at 12 40 52 pm" src="https://cloud.githubusercontent.com/assets/4141884/19487312/44674d72-9530-11e6-97a2-faa495d22f45.png">

cc @gchomatas @markhazlewood @jonathanwgoodwin 
