### PR TITLE
Remove old git info links from UI

### DIFF
--- a/BlazarUI/app/scripts/components/branch-state/BranchBuildHeader.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/BranchBuildHeader.jsx
@@ -3,7 +3,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 
 import BuildTriggerLabel from './shared/BuildTriggerLabel.jsx';
 import UsersForBuild from './shared/UsersForBuild.jsx';
-import CommitInfo from './shared/CommitInfo.jsx';
 import CancelBuildButton from '../shared/branch-build/CancelBuildButton.jsx';
 import CommitsSummary from './shared/CommitsSummary.jsx';
 
@@ -30,7 +29,6 @@ const BranchBuildHeader = ({branchBuild, onCancelBuild}) => {
           btnStyle="link"
           btnClassName="branch-build-header__cancel-build-button"
         />
-        <CommitInfo commitInfo={commitInfo} />
       </span>
     </div>
   );

--- a/BlazarUI/app/scripts/components/branch-state/module-build-history/ModuleBuildHistoryItem.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/module-build-history/ModuleBuildHistoryItem.jsx
@@ -5,7 +5,6 @@ import { withRouter, routerShape } from 'react-router';
 import ModuleBuildNumber from '../shared/ModuleBuildNumber.jsx';
 import ModuleBuildStatus from '../shared/ModuleBuildStatus.jsx';
 import BuildTriggerLabel from '../shared/BuildTriggerLabel.jsx';
-import CommitInfoLink from '../shared/CommitInfoLink.jsx';
 import UsersForBuild from '../shared/UsersForBuild.jsx';
 import CommitsSummary from '../shared/CommitsSummary.jsx';
 
@@ -39,7 +38,6 @@ const ModuleBuildHistoryItem = ({moduleBuild, moduleName, branchBuild, router}) 
           <div className="module-build-history-item__build-trigger-label">
             <BuildTriggerLabel buildTrigger={branchBuild.get('buildTrigger')} />
           </div>
-          <CommitInfoLink commitInfo={commitInfo} className="module-build-history-item__commit-info" />
       </div>
     </li>
   );

--- a/BlazarUI/app/stylus/components/branch-state/module-build-history.styl
+++ b/BlazarUI/app/stylus/components/branch-state/module-build-history.styl
@@ -46,13 +46,9 @@
 
 .module-build-history-item__build-trigger-label
   font-size 12px
-  position absolute
-  right 30px
-
-.module-build-history-item__commit-info
-  margin 5px
-  width 20px
-  text-align center
+  width 100px
+  text-align right
+  margin-right 5px
 
 .module-build-history-item--clickable
   cursor pointer


### PR DESCRIPTION
Separate commit will immediately follow to more thoroughly cleanup unused components.

<img width="1023" alt="screen shot 2016-10-18 at 4 01 43 pm" src="https://cloud.githubusercontent.com/assets/4141884/19494289/706143b2-954c-11e6-8264-46fddbc407fc.png">

cc @markhazlewood @gchomatas 
