### PR TITLE
Speed up response time when switching sidebar tabs

### DIFF
--- a/BlazarUI/app/scripts/components/sidebar/SidebarContainer.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarContainer.jsx
@@ -38,11 +38,9 @@ class SidebarContainer extends Component {
     this.state = {
       builds: undefined,
       loading: true,
-      changingBuildsType: false,
       filterText: '',
       toggleFilterState: sidebarTabProvider.getSidebarTab(),
-      sidebarHeight: this.getSidebarHeight(),
-      dontDisplay: true
+      sidebarHeight: this.getSidebarHeight()
     };
   }
 
@@ -95,14 +93,10 @@ class SidebarContainer extends Component {
   }
 
   setToggleState(toggleState) {
-    BuildsActions.loadBuilds();
     sidebarTabProvider.changeTab(toggleState);
 
     this.setState({
-      filterText: this.state.filterText,
-      toggleFilterState: toggleState,
-      changingBuildsType: true,
-      dontDisplay: true
+      toggleFilterState: toggleState
     });
   }
 

--- a/BlazarUI/app/scripts/components/sidebar/SidebarMessage.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarMessage.jsx
@@ -2,12 +2,8 @@ import React, {PropTypes} from 'react';
 import MutedMessage from '../shared/MutedMessage.jsx';
 import {NO_MATCH_MESSAGES} from '../constants';
 
-const SidebarMessage = ({dontDisplay, numberOfBuilds, filterText, toggleFilterState}) => {
+const SidebarMessage = ({numberOfBuilds, filterText, toggleFilterState}) => {
   let message = null;
-  // dont display any messages while we are toggling
-  if (dontDisplay) {
-    return null;
-  }
 
   if (!numberOfBuilds && filterText.length) {
     message = (
@@ -30,8 +26,7 @@ const SidebarMessage = ({dontDisplay, numberOfBuilds, filterText, toggleFilterSt
 SidebarMessage.propTypes = {
   numberOfBuilds: PropTypes.number,
   filterText: PropTypes.string,
-  toggleFilterState: PropTypes.string,
-  dontDisplay: PropTypes.bool
+  toggleFilterState: PropTypes.string
 };
 
 export default SidebarMessage;

--- a/BlazarUI/app/scripts/components/sidebar/SidebarRepoList.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarRepoList.jsx
@@ -1,6 +1,5 @@
 import React, {Component, PropTypes} from 'react';
 import LazyRender from '../shared/LazyRender.jsx';
-import Loader from '../shared/Loader.jsx';
 import SidebarItem from './SidebarItem.jsx';
 import {sortBuildsByRepoAndBranch, filterInactiveBuilds} from '../Helpers.js';
 
@@ -61,16 +60,10 @@ class SidebarRepoList extends Component {
   }
 
   render() {
-    const {changingBuildsType, filteredBuilds, loading} = this.props;
+    const {filteredBuilds, loading} = this.props;
 
     if (loading) {
       return null;
-    }
-
-    if (changingBuildsType) {
-      return (
-        <Loader align="top-center" className="sidebar-loader" />
-      );
     }
 
     return (
@@ -86,7 +79,6 @@ class SidebarRepoList extends Component {
 
 SidebarRepoList.propTypes = {
   sidebarHeight: PropTypes.number.isRequired,
-  changingBuildsType: PropTypes.bool.isRequired,
   filteredBuilds: PropTypes.object.isRequired,
   loading: PropTypes.bool.isRequired,
   filterText: PropTypes.string.isRequired

--- a/BlazarUI/app/scripts/stores/buildsStore.js
+++ b/BlazarUI/app/scripts/stores/buildsStore.js
@@ -39,8 +39,6 @@ const BuildsStore = Reflux.createStore({
       if (err) {
         this.trigger({
           loading: false,
-          dontDisplay: false,
-          changingBuildsType: false,
           error: {
             status: err.status,
             statusText: err.statusText
@@ -52,9 +50,7 @@ const BuildsStore = Reflux.createStore({
 
       this.trigger({
         builds: this.builds,
-        loading: false,
-        dontDisplay: false,
-        changingBuildsType: false
+        loading: false
       });
     });
   }


### PR DESCRIPTION
Because we are already polling for builds in the sidebar, don't
refresh the sidebar data and display a loading icon when switching
tabs.
