### PR TITLE
Branch Name validation

### DIFF
--- a/BlazarData/src/test/java/com/hubspot/blazar/data/service/BranchServiceTest.java
+++ b/BlazarData/src/test/java/com/hubspot/blazar/data/service/BranchServiceTest.java
@@ -54,7 +54,6 @@ public class BranchServiceTest extends DatabaseBackedTest {
     assertThat(retrieved.isPresent()).isTrue();
     assertThat(retrieved.get()).isEqualTo(renamed);
     assertThat(retrieved.get().getUpdatedTimestamp()).isBetween(before, System.currentTimeMillis());
-    assertThat(retrieved.get().getUpdatedTimestamp()).isGreaterThan(retrieved.get().getCreatedTimestamp());
   }
 
   @Test

--- a/BlazarService/src/main/java/com/hubspot/blazar/discovery/CompositeModuleDiscovery.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/discovery/CompositeModuleDiscovery.java
@@ -98,7 +98,7 @@ public class CompositeModuleDiscovery implements ModuleDiscovery {
     String branch = gitInfo.getBranch();
     if (branch.contains("'") ||
         branch.contains("\"") ||
-        CharMatcher.ASCII.matchesAllOf(branch)) {
+        ! CharMatcher.ASCII.matchesAllOf(branch)) {
       String message = String.format("Branch %s contained non-ascii or quotation characters not supported by Blazar.\nPlease re-create your branch with a new name.", branch);
       return Optional.of(new MalformedFile(gitInfo.getId().get(), "branch-validation", "/", message));
     }

--- a/BlazarService/src/main/java/com/hubspot/blazar/discovery/CompositeModuleDiscovery.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/discovery/CompositeModuleDiscovery.java
@@ -87,9 +87,9 @@ public class CompositeModuleDiscovery implements ModuleDiscovery {
   }
 
   /**
-   * There are certain characters which (currently) play havoc with our downstream build tooling (our executor).
-   * In order to prevent downstream failures we validate here in order to make sure that branches we cannot handle,
-   * are not consumed by downstream services. Ideally those services would be more resilient but at this time they are not.
+   * Currently we do not support branch names with special characters despite the fact that github allows certain special
+   * characters in branch names (e.g. a single quote). Having special characters in the branch name causes problems in
+   * services that blazar uses to handle builds, i.e. the build executor and our maven service that detects modules.
    *
    * @param gitInfo The branch we are checking for validity.
    * @return A malformed "file" representing the invalid branch name if it is invalid

--- a/BlazarService/src/main/java/com/hubspot/blazar/discovery/CompositeModuleDiscovery.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/discovery/CompositeModuleDiscovery.java
@@ -1,19 +1,22 @@
 package com.hubspot.blazar.discovery;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import com.google.common.base.CharMatcher;
+import com.google.common.base.Optional;
 import com.google.common.collect.ImmutableSet;
 import com.hubspot.blazar.base.CommitInfo;
 import com.hubspot.blazar.base.DiscoveredModule;
 import com.hubspot.blazar.base.DiscoveryResult;
 import com.hubspot.blazar.base.GitInfo;
 import com.hubspot.blazar.base.MalformedFile;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 
 @Singleton
 public class CompositeModuleDiscovery implements ModuleDiscovery {
@@ -41,6 +44,11 @@ public class CompositeModuleDiscovery implements ModuleDiscovery {
   public DiscoveryResult discover(GitInfo gitInfo) throws IOException {
     Map<String, Set<DiscoveredModule>> modulesByPath = new HashMap<>();
     Set<MalformedFile> malformedFiles = new HashSet<>();
+
+    Optional<MalformedFile> malformedBranchFile = preDiscoveryBranchValidation(gitInfo);
+    if (malformedBranchFile.isPresent()) {
+      return new DiscoveryResult(ImmutableSet.of(), ImmutableSet.of(malformedBranchFile.get()));
+    }
 
     for (ModuleDiscovery delegate : delegates) {
       DiscoveryResult result = delegate.discover(gitInfo);
@@ -76,5 +84,25 @@ public class CompositeModuleDiscovery implements ModuleDiscovery {
     }
 
     return new DiscoveryResult(modules, malformedFiles);
+  }
+
+  /**
+   * There are certain characters which (currently) play havoc with our downstream build tooling (our executor).
+   * In order to prevent downstream failures we validate here in order to make sure that branches we cannot handle,
+   * are not consumed by downstream services. Ideally those services would be more resilient but at this time they are not.
+   *
+   * @param gitInfo The branch we are checking for validity.
+   * @return A malformed "file" representing the invalid branch name if it is invalid
+   */
+  private Optional<MalformedFile> preDiscoveryBranchValidation(GitInfo gitInfo) {
+    String branch = gitInfo.getBranch();
+    if (branch.contains("'") ||
+        branch.contains("\"") ||
+        CharMatcher.ASCII.matchesAllOf(branch)) {
+      String message = String.format("Branch %s contained non-ascii or quotation characters not supported by Blazar.\nPlease re-create your branch with a new name.", branch);
+      return Optional.of(new MalformedFile(gitInfo.getId().get(), "branch-validation", "/", message));
+    }
+
+    return Optional.absent();
   }
 }


### PR DESCRIPTION
Adds validation to prevent discovery of branches with weird chars from breaking blazar.
cc: @gchomatas 