### PR TITLE
Covert git commit info to standard popover

### DIFF
--- a/BlazarUI/app/scripts/components/branch-state/shared/CommitsSummaryPopover.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/shared/CommitsSummaryPopover.jsx
@@ -3,7 +3,6 @@ import ImmutablePropTypes from 'react-immutable-proptypes';
 import classNames from 'classnames';
 
 import Icon from '../../shared/Icon.jsx';
-import Image from '../../shared/Image.jsx';
 import { truncate } from '../../Helpers';
 
 const MAX_COMMITS_DISPLAYED = 5;
@@ -13,7 +12,7 @@ const CommitRowIcon = ({isFirstRow}) => {
   if (isFirstRow) {
     return (
       <div className="commits-summary-poverover__branch-head-icon">
-        <Image src={`${window.config.staticRoot}/images/branch_head.png`} height={25} width={25} />
+        <Icon type="octicon" name="git-branch" />
       </div>
     );
   }
@@ -46,7 +45,7 @@ const CommitRow = ({commit, index}) => {
         <CommitRowIcon isFirstRow={isFirstRow} />
       </td>
       <td className="commits-summary-popover__commit-message">
-        <a href={commit.get('url')} target="_blank">{formattedCommitMessage}</a>
+        {formattedCommitMessage}
       </td>
     </tr>
   );
@@ -60,13 +59,19 @@ CommitRow.propTypes = {
   index: PropTypes.number.isRequired
 };
 
-const CommitsSummaryPopover = ({commitList, compareCommitsUrl}) => {
+const CommitsSummaryPopover = ({commitList, viewCommitsInGitHubUrl}) => {
   const truncateCommits = commitList.size > MAX_COMMITS_DISPLAYED;
   const displayedCommits = commitList.take(MAX_COMMITS_DISPLAYED);
   const singleCommit = commitList.size === 1;
 
-  const externalLinkText = truncateCommits ?
-    `View all ${commitList.size} commits` : 'View commits in github';
+  let externalLinkText;
+  if (singleCommit) {
+    externalLinkText = 'View in GitHub';
+  } else if (truncateCommits) {
+    externalLinkText = `View all ${commitList.size} commits in GitHub`;
+  } else {
+    externalLinkText = 'View commits in GitHub';
+  }
 
   const tableClassNames = classNames('commits-summary-popover__commit-list',
     {'commits-summary-popover__commit-list--single-commit': singleCommit});
@@ -80,24 +85,22 @@ const CommitsSummaryPopover = ({commitList, compareCommitsUrl}) => {
           }
         </tbody>
       </table>
-      {!singleCommit && (
-        <p className="commits-summary-popover__footer">
-          <a
-            className="commits-summary-popover__view-commits-link"
-            href={compareCommitsUrl}
-            target="_blank"
-          >
-            {externalLinkText} <Icon name="external-link" />
-          </a>
-        </p>
-      )}
+      <p className="commits-summary-popover__footer">
+        <a
+          className="commits-summary-popover__view-commits-link"
+          href={viewCommitsInGitHubUrl}
+          target="_blank"
+        >
+          {externalLinkText} <Icon name="external-link" />
+        </a>
+      </p>
     </div>
   );
 };
 
 CommitsSummaryPopover.propTypes = {
   commitList: ImmutablePropTypes.list.isRequired,
-  compareCommitsUrl: PropTypes.string.isRequired
+  viewCommitsInGitHubUrl: PropTypes.string.isRequired
 };
 
 export default CommitsSummaryPopover;

--- a/BlazarUI/app/stylus/components/branch-state/commits-summary.styl
+++ b/BlazarUI/app/stylus/components/branch-state/commits-summary.styl
@@ -1,16 +1,21 @@
 @import '../../variables'
 
 .commits-summary
-  color $color-calypso
-  padding 0 5px
+  padding 0 5px !important
+  border none !important
+  font-size inherit
   white-space nowrap
+
+.commits-summary-icon
+  margin-right 5px
 
 .commits-summary-popover
   max-width 300px
   font-size 12px
-
+  color $color-heffalump
+  font-family "Avenir Next", "Helvetica Neue", Helvetica, Arial, sans-serif
   a
-    color $color-gypsum !important
+    color $color-calypso
 
 .commits-summary-popover__commit-list
   position relative
@@ -19,19 +24,20 @@
 
   &:not(.commits-summary-popover__commit-list--single-commit):before
     position absolute
-    top 30px
+    top 49 px
     bottom 0
-    left 12px
+    left 11px
     width 1px
     content ""
-    background-color $color-gypsum
+    background-color $color-eerie
     z-index -1
 
 .commits-summary-poverover__commit-icon
   width 24px
   text-align center
   vertical-align top
-  padding-top 6px
+  padding-top 7px
+  color $color-eerie
 
 .commits-summary-poverover__commit-icon--first
   vertical-align middle
@@ -39,22 +45,36 @@
 
 .commits-summary-poverover__branch-head-icon
   padding-bottom 2px
-  background-color $color-heffalump
+  position relative
+  left 0.5px
+
+  &:before
+    background-color $color-battleship
+    position absolute
+    left 1px
+    top -2px
+    width 21px
+    height 21px
+    z-index -1
+    transform rotate(45deg)
+    border-radius 4px
+    content ""
 
 .commits-summary-poverover__git-commit-icon
-  background-color $color-heffalump
+  background-color $color-calypso-light
   line-height 13px
 
 .commits-summary-popover__commit-message
   padding-left 10px
-  font-style italic
   padding-top 6px
   padding-bottom 6px
   max-width 225px
   overflow hidden
   text-overflow ellipsis
+  line-height 18px
+  font-size 12px
 
 .commits-summary-popover__footer
-  margin-top 14px
+  margin-top 8px
   margin-bottom 0
   text-align right

--- a/BlazarUI/app/stylus/page/branch-state.styl
+++ b/BlazarUI/app/stylus/page/branch-state.styl
@@ -11,44 +11,6 @@
     margin-left -40px
     margin-right -20px
 
-  a
-    color $color-calypso
-
-  .btn
-    radius 3px
-    padding: 0.75rem 1.5rem
-
-  .btn-lg
-    font-size 18px
-
-  .btn-default
-    color $color-button-secondary-text
-    background-color $color-olaf
-    border-color $color-lorax
-
-    &:hover,
-    &:focus
-      background-color $color-button-secondary-hover-fill
-      color $color-button-secondary-text
-
-    &:active
-      background-color $color-button-secondary-active-fill
-
-  .btn-primary
-    color $color-olaf
-    background-color $color-lorax
-    border-color $color-lorax
-
-    &:hover,
-    &:focus
-      background-color $color-button-primary-hover-fill
-      border-color $color-button-primary-hover-fill
-      color $color-olaf
-
-    &:active
-      background-color $color-lorax-dark
-      border-color $color-lorax-dark
-
 .branch-state-headline__repo-icon
   margin-right 10px
   color $color-eerie

--- a/BlazarUI/app/stylus/vendor-overrides/bootstrap-overrides.styl
+++ b/BlazarUI/app/stylus/vendor-overrides/bootstrap-overrides.styl
@@ -9,7 +9,9 @@ $pagination-hover-bg ?= $color-koala
 
 $tooltip-bg ?= $color-heffalump
 $tooltip-opacity ?= 1
-$popover-bg ?= $color-heffalump
+$popover-bg ?= $color-calypso-light
+$popover-border-color ?= $color-calypso-light
+$popover-arrow-outer-color ?= $color-calypso-light
 
 $text-muted ?= $color-eerie
 
@@ -56,3 +58,49 @@ label
 
 .tooltip-inner, .popover-content
   color $color-gypsum
+
+// For now, scope these overrides to new pages to avoid breaking existing
+// designs. This is not ideal because it causes some specificity issues
+// and we should settle on a consistent set of bootstrap overrides
+// across the entire app soon.
+.page-content--branch-state
+  a
+    color $color-calypso
+
+  .btn
+    radius 3px
+    padding: 0.75rem 1.5rem
+
+  .btn-link
+    color $color-calypso
+
+  .btn-lg
+    font-size 18px
+
+  .btn-default
+    color $color-button-secondary-text
+    background-color $color-olaf
+    border-color $color-lorax
+
+    &:hover,
+    &:focus
+      background-color $color-button-secondary-hover-fill
+      color $color-button-secondary-text
+
+    &:active
+      background-color $color-button-secondary-active-fill
+
+  .btn-primary
+    color $color-olaf
+    background-color $color-lorax
+    border-color $color-lorax
+
+    &:hover,
+    &:focus
+      background-color $color-button-primary-hover-fill
+      border-color $color-button-primary-hover-fill
+      color $color-olaf
+
+    &:active
+      background-color $color-lorax-dark
+      border-color $color-lorax-dark


### PR DESCRIPTION
Users were confused by the previous 'tooltip' and would try to
clik on it. They were also not aware that they could click
on the links within the previous commit summary tooltip.

Users will now have to click on the link to open the popover
and click anywhere outside of the popover to close it.

<img width="398" alt="screen shot 2016-11-03 at 7 14 21 pm" src="https://cloud.githubusercontent.com/assets/4141884/19988998/ed1f25f4-a1f9-11e6-9444-4a415817e158.png">
<img width="284" alt="screen shot 2016-11-03 at 7 14 34 pm" src="https://cloud.githubusercontent.com/assets/4141884/19988997/ed1dd6b8-a1f9-11e6-9706-f5091f77da8b.png">
<img width="411" alt="screen shot 2016-11-03 at 7 15 00 pm" src="https://cloud.githubusercontent.com/assets/4141884/19988999/ed2114cc-a1f9-11e6-984d-68f49dd5c3be.png">

cc @markhazlewood @gchomatas @jonathanwgoodwin 