### PR TITLE
Fix silently thrown error when using search bar in Firefox

### DIFF
--- a/BlazarUI/app/scripts/components/shared/SearchFilter.jsx
+++ b/BlazarUI/app/scripts/components/shared/SearchFilter.jsx
@@ -51,7 +51,7 @@ class SearchFilter extends Component {
 
   handleKeyup(e) {
     const notFocusedOnInputElement = e.target === document.body || e.target.tagName === 'A';
-    const modifierKey = e.metaKey || e.shiftKey || event.ctrlKey;
+    const modifierKey = e.metaKey || e.shiftKey || e.ctrlKey;
     const shortcutPressed = contains(FOCUS_SEARCH_BAR_SHORTCUTS, e.which);
     if (shortcutPressed && !modifierKey && notFocusedOnInputElement) {
       this.focusInput();


### PR DESCRIPTION
Error was not thrown by chrome because chrome defines window.event
to be compatible with old versions of IE