### PR TITLE
Display an error message for paths with an invalid build number

### DIFF
--- a/BlazarUI/app/scripts/components/repo-build/RepoBuildContainer.jsx
+++ b/BlazarUI/app/scripts/components/repo-build/RepoBuildContainer.jsx
@@ -30,7 +30,8 @@ const initialState = {
   branchInfo: {},
   upAndDownstreamModules: {},
   currentRepoBuild: null,
-  loadingUpAndDownstreamModules: true
+  loadingUpAndDownstreamModules: true,
+  error: null
 };
 
 class RepoBuildContainer extends Component {

--- a/BlazarUI/app/scripts/data/RepoBuildApi.js
+++ b/BlazarUI/app/scripts/data/RepoBuildApi.js
@@ -12,25 +12,14 @@ function _parse(resp) {
   return resp;
 }
 
-function _fetchModuleNames(params) {
-  const moduleNamesPromise = new Resource({
-    url: `${window.config.apiRoot}/branches/${params.branchId}/modules`,
-    type: 'GET'
-  }).send();
-
-  return moduleNamesPromise;
-}
-
-function _fetchModuleNamesById(branchId) {
-  const moduleNamesPromise = new Resource({
+function _fetchModuleNames(branchId) {
+  return new Resource({
     url: `${window.config.apiRoot}/branches/${branchId}/modules`,
     type: 'GET'
   }).send();
-
-  return moduleNamesPromise;
 }
 
-function _fetchBranchBuildHistory(params) {
+function _fetchBranchBuildHistory(branchId) {
   const inclusionOpts = {
     property: [
       'buildNumber',
@@ -39,98 +28,60 @@ function _fetchBranchBuildHistory(params) {
     ]
   };
 
-  const branchBuildHistoryPromise = new Resource({
-    url: `${window.config.apiRoot}/builds/history/branch/${params.branchId}`,
+  return new Resource({
+    url: `${window.config.apiRoot}/builds/history/branch/${branchId}`,
     type: 'GET',
     data: $.param(inclusionOpts, true)
   }).send();
-
-  return branchBuildHistoryPromise;
 }
 
-function _getRepoBuildByParam(params, resp) {
-  if (params.buildNumber === 'latest') {
-    resp = resp.filter((build) => {
+function _getRepoBuildByParam(buildNumber, repoBuilds) {
+  if (buildNumber === 'latest') {
+    const notStartedBuilds = repoBuilds.filter((build) => {
       return !contains(['QUEUED', 'LAUNCHING', 'WAITING_FOR_BUILD_SLOT', 'WAITING_FOR_UPSTREAM_BUILD'], build.state);
     });
-    return max(resp, (build) => {
-      return build.buildNumber;
-    });
+
+    return max(notStartedBuilds, (build) => build.buildNumber);
   }
 
-  return findWhere(resp, {buildNumber: parseInt(params.buildNumber, 10)});
+  return findWhere(repoBuilds, {buildNumber: parseInt(buildNumber, 10)});
 }
 
-function _fetchRepoBuildId(params) {
-  return Q(_fetchBranchBuildHistory(params)).then((resp) => {
-    const repoBuild = _getRepoBuildByParam(params, resp);
+function _fetchRepoBuildId(branchId, buildNumber) {
+  return Q(_fetchBranchBuildHistory(branchId)).then((resp) => {
+    const repoBuild = _getRepoBuildByParam(buildNumber, resp);
 
     if (!repoBuild) {
-      return Q.reject(`Build #${params.buildNumber} does not exist for this branch.`);
+      return Q.reject(`Build #${buildNumber} does not exist for this branch.`);
     }
 
     return repoBuild.id;
   });
 }
 
-function fetchRepoBuild(params) {
-  return _fetchRepoBuildId(params)
-    .then((repoBuildId) => {
-      const repoBuildPromise = new Resource({
-        url: `${window.config.apiRoot}/branches/builds/${repoBuildId}`,
-        type: 'GET'
-      }).send();
-
-      return repoBuildPromise;
-    }).then((repoBuilds) => _parse(repoBuilds));
-}
-
-function fetchRepoBuildById(repoBuildId, cb) {
+function fetchRepoBuildById(repoBuildId) {
   const repoBuildPromise = new Resource({
     url: `${window.config.apiRoot}/branches/builds/${repoBuildId}`,
     type: 'GET'
   }).send();
 
-  return repoBuildPromise.then((resp) => {
-    return cb(_parse(resp));
-  });
+  return repoBuildPromise.then((repoBuilds) => _parse(repoBuilds));
 }
 
-function fetchModuleBuilds(params) {
-  return _fetchRepoBuildId(params).then((repoBuildId) => {
-    const {branchId, buildNumber} = params;
-
-    const moduleInfoPromise = _fetchModuleNames(params);
-    const moduleBuildsPromise = new Resource({
-      url: `${window.config.apiRoot}/branches/builds/${repoBuildId}/modules`,
-      type: 'GET'
-    }).send();
-
-    return Q.spread([moduleInfoPromise, moduleBuildsPromise],
-      (moduleInfos, moduleBuilds) => {
-        const moduleBuildsWithNames = map(moduleBuilds, (build) => {
-          const moduleInfo = findWhere(moduleInfos, {id: build.moduleId});
-          const moduleInfoExtended = {
-            name: moduleInfo.name,
-            blazarPath: `/builds/branch/${branchId}/build/${buildNumber}/module/${moduleInfo.name}`
-          };
-
-          return extend(build, moduleInfoExtended);
-        });
-
-        return moduleBuildsWithNames;
-      });
-  });
+function fetchRepoBuild(params) {
+  const {branchId, buildNumber} = params;
+  return _fetchRepoBuildId(branchId, buildNumber)
+    .then(fetchRepoBuildById);
 }
 
-function fetchModuleBuildsById(branchId, repoBuildId, buildNumber, cb) {
+function fetchModuleBuildsById(branchId, repoBuildId, buildNumber) {
+  const moduleInfoPromise = _fetchModuleNames(branchId);
   const moduleBuildsPromise = new Resource({
     url: `${window.config.apiRoot}/branches/builds/${repoBuildId}/modules`,
     type: 'GET'
   }).send();
-  const moduleInfoPromise = _fetchModuleNamesById(branchId);
 
-  Q.spread([moduleInfoPromise, moduleBuildsPromise],
+  return Q.spread([moduleInfoPromise, moduleBuildsPromise],
     (moduleInfos, moduleBuilds) => {
       const moduleBuildsWithNames = map(moduleBuilds, (build) => {
         const moduleInfo = findWhere(moduleInfos, {id: build.moduleId});
@@ -142,8 +93,15 @@ function fetchModuleBuildsById(branchId, repoBuildId, buildNumber, cb) {
         return extend(build, moduleInfoExtended);
       });
 
-      cb(moduleBuildsWithNames);
+      return moduleBuildsWithNames;
     });
+}
+
+function fetchModuleBuilds(params) {
+  const {branchId, buildNumber} = params;
+  return _fetchRepoBuildId(branchId, buildNumber).then((repoBuildId) => {
+    return fetchModuleBuildsById(branchId, repoBuildId, buildNumber);
+  });
 }
 
 function cancelBuild(repoBuildId) {

--- a/BlazarUI/app/scripts/stores/repoBuildStore.js
+++ b/BlazarUI/app/scripts/stores/repoBuildStore.js
@@ -51,12 +51,13 @@ const RepoBuildStore = Reflux.createStore({
   },
 
   onLoadRepoBuildById(repoBuildId) {
-    RepoBuildApi.fetchRepoBuildById(repoBuildId, (resp) => {
-      this.trigger({
-        repoBuild: resp,
-        loading: false
+    RepoBuildApi.fetchRepoBuildById(repoBuildId)
+      .then((resp) => {
+        this.trigger({
+          repoBuild: resp,
+          loading: false
+        });
       });
-    });
   },
 
   onLoadModuleBuilds(params) {
@@ -86,14 +87,15 @@ const RepoBuildStore = Reflux.createStore({
   },
 
   onLoadModuleBuildsById(branchId, repoBuildId, buildNumber) {
-    RepoBuildApi.fetchModuleBuildsById(branchId, repoBuildId, buildNumber, (resp) => {
-      this.moduleBuildsList = resp;
+    RepoBuildApi.fetchModuleBuildsById(branchId, repoBuildId, buildNumber)
+      .then((resp) => {
+        this.moduleBuildsList = resp;
 
-      this.trigger({
-        moduleBuildsList: this.moduleBuildsList,
-        loading: false
+        this.trigger({
+          moduleBuildsList: this.moduleBuildsList,
+          loading: false
+        });
       });
-    });
   },
 
   onStartPolling(params) {

--- a/BlazarUI/app/scripts/stores/repoBuildStore.js
+++ b/BlazarUI/app/scripts/stores/repoBuildStore.js
@@ -25,19 +25,29 @@ const RepoBuildStore = Reflux.createStore({
       return;
     }
 
-    this.isRequestingRepoBuild = RepoBuildApi.fetchRepoBuild(params, (resp) => {
-      this.repoBuild = resp;
-      this.isRequestingRepoBuild = false;
+    this.isRequestingRepoBuild = true;
 
-      if (buildIsInactive(this.repoBuild.state)) {
+    RepoBuildApi.fetchRepoBuild(params)
+      .then((resp) => {
+        this.repoBuild = resp;
+        this.isRequestingRepoBuild = false;
+
+        if (buildIsInactive(this.repoBuild.state)) {
+          this.shouldPoll = false;
+        }
+
+        this.trigger({
+          currentRepoBuild: this.repoBuild,
+          loadingRepoBuild: false
+        });
+      }, (error) => {
+        this.isRequestingRepoBuild = false;
         this.shouldPoll = false;
-      }
-
-      this.trigger({
-        currentRepoBuild: this.repoBuild,
-        loadingRepoBuild: false
+        this.trigger({
+          error,
+          loadingRepoBuild: false
+        });
       });
-    });
   },
 
   onLoadRepoBuildById(repoBuildId) {
@@ -56,15 +66,23 @@ const RepoBuildStore = Reflux.createStore({
       return;
     }
 
-    this.isRequestingModuleBuilds = RepoBuildApi.fetchModuleBuilds(params, (resp) => {
-      this.moduleBuilds = resp;
-      this.isRequestingModuleBuilds = false;
+    this.isRequestingModuleBuilds = true;
+    RepoBuildApi.fetchModuleBuilds(params)
+      .then((resp) => {
+        this.moduleBuilds = resp;
+        this.isRequestingModuleBuilds = false;
 
-      this.trigger({
-        moduleBuilds: this.moduleBuilds,
-        loadingModuleBuilds: false
+        this.trigger({
+          moduleBuilds: this.moduleBuilds,
+          loadingModuleBuilds: false
+        });
+      }, (error) => {
+        this.isRequestingModuleBuilds = false;
+        this.trigger({
+          error,
+          loadingModuleBuilds: false
+        });
       });
-    });
   },
 
   onLoadModuleBuildsById(branchId, repoBuildId, buildNumber) {


### PR DESCRIPTION
Previously, entering in an invalid build number for the BlazarUI
path /builds/branch/{branchId}/build/{buildNumber} would cause
the app to crash

cc @jonathanwgoodwin 