### PR TITLE
Filter out modules with no builds on branch state page

### DIFF
--- a/BlazarUI/app/scripts/selectors/index.js
+++ b/BlazarUI/app/scripts/selectors/index.js
@@ -31,11 +31,20 @@ export const getBranchesInRepository = createSelector(
 
 const getModuleStates = (state) => state.branchState.get('moduleStates');
 
-export const getActiveModules = createSelector([getModuleStates],
+// For now, only display modules with builds on the branch state page
+const getModulesWithBuilds = createSelector([getModuleStates],
+  (moduleStates) => moduleStates.filter(moduleState =>
+    moduleState.has('inProgressBranchBuild') ||
+    moduleState.has('pendingBranchBuild') ||
+    moduleState.has('lastBranchBuild')
+  )
+);
+
+export const getActiveModules = createSelector([getModulesWithBuilds],
   (moduleStates) => moduleStates.filter(moduleState => moduleState.getIn(['module', 'active']))
 );
 
-export const getInactiveModules = createSelector([getModuleStates],
+export const getInactiveModules = createSelector([getModulesWithBuilds],
   (moduleStates) => moduleStates.filter(moduleState => !moduleState.getIn(['module', 'active']))
 );
 


### PR DESCRIPTION
This prevents a null pointer exception from breaking the page when there
is a module that hasn't been built yet. These modules will be displayed
on the page when we incorporate the styling updates for the module items.

cc @jonathanwgoodwin @markhazlewood 