### PR TITLE
Report all ajax errors to Sentry

### DIFF
--- a/BlazarUI/app/scripts/main.js
+++ b/BlazarUI/app/scripts/main.js
@@ -9,6 +9,7 @@ import { Provider } from 'react-redux';
 import store from './reduxStore';
 
 import { getUsernameFromCookie } from './components/Helpers.js';
+import { configureSentry } from './sentry';
 
 const username = getUsernameFromCookie();
 
@@ -21,7 +22,7 @@ if (window.config.heapToken) {
 }
 
 if (window.config.sentryDsn) {
-  window.Raven.setUserContext({username});
+  configureSentry();
 }
 
 const browserHistory = useRouterHistory(createHistory)({

--- a/BlazarUI/app/scripts/sentry.js
+++ b/BlazarUI/app/scripts/sentry.js
@@ -1,0 +1,26 @@
+import { getUsernameFromCookie } from './components/Helpers.js';
+import $ from 'jquery';
+
+const username = getUsernameFromCookie();
+
+const captureAjaxError = (event, xhr, ajaxSettings) => {
+  const {status, statusText, responseText, responseJSON} = xhr;
+  const {type, url} = ajaxSettings;
+
+  window.Raven.captureMessage('Ajax Error', {
+    extra: {
+      status,
+      statusText,
+      responseText,
+      responseJSON,
+      requestMethod: type,
+      requestUrl: url,
+      url: window.location.href
+    }
+  });
+};
+
+export const configureSentry = () => {
+  window.Raven.setUserContext({username});
+  $(document).ajaxError(captureAjaxError);
+};

--- a/BlazarUI/app/scripts/sentry.js
+++ b/BlazarUI/app/scripts/sentry.js
@@ -7,6 +7,12 @@ const captureAjaxError = (event, xhr, ajaxSettings) => {
   const {status, statusText, responseText, responseJSON} = xhr;
   const {type, url} = ajaxSettings;
 
+  // only report errors returned by api requests, not browser level
+  // errors (e.g. when the user is not connected to the internet)
+  if (status === 0) {
+    return;
+  }
+
   window.Raven.captureMessage('Ajax Error', {
     extra: {
       status,


### PR DESCRIPTION
This helps us debug errors by including more context about any
failed requests.

cc @gchomatas @jonathanwgoodwin 