### PR TITLE
Fix error handling for builds endpoint

### DIFF
--- a/BlazarUI/app/scripts/components/repo/RepoContainer.jsx
+++ b/BlazarUI/app/scripts/components/repo/RepoContainer.jsx
@@ -59,16 +59,19 @@ class RepoContainer extends Component {
     });
   }
 
-  onStatusChange(state) {
-    if (state.error) {
-      state.loading = false;
+  onStatusChange(status) {
+    if (status.error && this.state.loading) {
+      this.setState({
+        loading: false,
+        error: 'Unable to load builds.'
+      });
+    } else if (status.builds) {
+      this.setState({
+        loading: false,
+        builds: this.getFilteredBuilds(this.props, status.builds.all),
+        error: null
+      });
     }
-
-    if (state.builds) {
-      state.builds = this.getFilteredBuilds(this.props, state.builds.all);
-    }
-
-    this.setState(state);
   }
 
   updateFilters(newFilters) {
@@ -95,9 +98,7 @@ class RepoContainer extends Component {
                 Branches
               </HeadlineDetail>
             </Headline>
-            <GenericErrorMessage
-              message={this.state.error}
-            />
+            <GenericErrorMessage message={this.state.error} />
             <BranchFilter
               hide={this.state.error}
               updateFilters={this.updateFilters}

--- a/BlazarUI/app/scripts/components/shared/AjaxErrorAlert.jsx
+++ b/BlazarUI/app/scripts/components/shared/AjaxErrorAlert.jsx
@@ -1,26 +1,36 @@
 // To do: Make this specific to ajax errors
-import React, {Component, PropTypes} from 'react';
+import React, {PropTypes} from 'react';
 import Alert from 'react-bootstrap/lib/Alert';
 
-class AjaxErrorAlert extends Component {
+const AjaxErrorAlert = ({error}) => {
+  if (!error) {
+    return null;
+  }
 
-  render() {
-    if (!this.props.error) {
-      return null;
-    }
-
+  const {status, responseText} = error;
+  if (status === 0) {
     return (
       <Alert bsStyle="danger">
-        <strong>Status {this.props.error.status}. Sorry, we're experiencing an error.</strong>
-        <p>Response: {this.props.error.responseText}</p>
-        <p>Check your console for more detail</p>
+        <strong>Sorry, we're having trouble getting data from Blazar.</strong>
+        <p>Try refreshing the page and verify that you are connected to the internet.</p>
       </Alert>
     );
   }
-}
+
+  return (
+    <Alert bsStyle="danger">
+      <strong>Status {status}. Sorry, we're experiencing an error.</strong>
+      {responseText && <p>Response: {responseText}</p>}
+      <p>Check your console for more detail</p>
+    </Alert>
+  );
+};
 
 AjaxErrorAlert.propTypes = {
-  error: PropTypes.node
+  error: PropTypes.shape({
+    status: PropTypes.number,
+    responseText: PropTypes.string
+  })
 };
 
 export default AjaxErrorAlert;

--- a/BlazarUI/app/scripts/data/BuildsApi.js
+++ b/BlazarUI/app/scripts/data/BuildsApi.js
@@ -98,12 +98,7 @@ function stopPolling() {
   this.buildsPoller.disconnect();
 }
 
-function fetchBuild() {
-
-}
-
 export default {
   fetchBuilds,
-  fetchBuild,
   stopPolling
 };


### PR DESCRIPTION
The repo page, sidebar, and dashboard all use data from the
same endpoint, which is managed by the BuildsStore.

When an error occurs on the repo page, we now have a message to display
instead of passing the error object into the GenericErrorMessage
component, which results in an exception.

Since errors for the builds endpoint are already shown in the sidebar,
don't display an error message on the repo page if the data has been
previously loaded successfully at least once. Just display whatever
builds have been previously loaded.

If the internet is disconnected, we have status 0 in the response.
The sidebar has been updated to display a more revelant message
instead of "Status 0" and an empty "Response:" section.

Because we are polling the sidebar data, only display an error if we
fail to fetch the data multiple times. This handles the case of a
user's computer taking some time to reconnect to the network more
gracefully.

cc @jonathanwgoodwin @markhazlewood 