### PR TITLE
WIP: Make GitHubHelper to be more helpful with GHerrors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 *.class
+.gitignore
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 *.class
-.gitignore
 
 # Mobile Tools for Java (J2ME)
 .mtj.tmp/
@@ -14,6 +13,5 @@ hs_err_pid*
 
 .idea/
 *.iml
-.gitignore
 
 target

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/CommitInfo.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/CommitInfo.java
@@ -1,12 +1,13 @@
 package com.hubspot.blazar.base;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Optional;
-import com.hubspot.blazar.github.GitHubProtos.Commit;
-
 import java.util.List;
 import java.util.Objects;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+import com.google.common.base.Optional;
+import com.hubspot.blazar.github.GitHubProtos.Commit;
 
 public class CommitInfo {
   private final Commit current;
@@ -39,6 +40,16 @@ public class CommitInfo {
 
   public boolean isTruncated() {
     return truncated;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("current", current)
+        .add("previous", previous)
+        .add("newCommits", newCommits)
+        .add("truncated", truncated)
+        .toString();
   }
 
   @Override

--- a/BlazarService/src/main/java/com/hubspot/blazar/command/GitBranchUpdater.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/command/GitBranchUpdater.java
@@ -1,7 +1,5 @@
 package com.hubspot.blazar.command;
 
-import java.io.IOException;
-
 import net.sourceforge.argparse4j.inf.Namespace;
 
 import org.kohsuke.github.GHRepository;
@@ -63,14 +61,7 @@ public class GitBranchUpdater implements Runnable {
     }
 
     GitHubConfiguration githubConfiguration = configuration.getGitHubConfiguration().get(oldBranch.getHost());
-    GHRepository ghRepository;
-    try {
-      ghRepository = gitHubHelper.repositoryFor(oldBranch);
-    } catch (IOException e) {
-      LOG.error("Caught exception while trying to find {} in github", oldBranch, e);
-      throw new RuntimeException(e);
-    }
-
+    GHRepository ghRepository = gitHubHelper.repositoryFor(oldBranch);
     if (ghRepository.getId() != oldBranch.getRepositoryId()) {
       LOG.warn("A repository with a different github id {} has replaced {}. Considering {}#{} as deleted ", ghRepository.getId(), oldBranch, oldBranch.getFullRepositoryName(), oldBranch.getBranch());
       branchService.delete(oldBranch);

--- a/BlazarService/src/main/java/com/hubspot/blazar/discovery/BlazarConfigModuleDiscovery.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/discovery/BlazarConfigModuleDiscovery.java
@@ -13,7 +13,6 @@ import org.kohsuke.github.GHTreeEntry;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.base.Optional;
 import com.google.common.base.Throwables;
 import com.hubspot.blazar.base.BuildConfig;
@@ -23,6 +22,7 @@ import com.hubspot.blazar.base.DiscoveredModule;
 import com.hubspot.blazar.base.DiscoveryResult;
 import com.hubspot.blazar.base.GitInfo;
 import com.hubspot.blazar.base.MalformedFile;
+import com.hubspot.blazar.exception.NonRetryableBuildException;
 import com.hubspot.blazar.util.GitHubHelper;
 
 @Singleton
@@ -81,7 +81,7 @@ public class BlazarConfigModuleDiscovery implements ModuleDiscovery {
       final BuildConfig buildConfig;
       try {
         buildConfig = gitHubHelper.configFor(blazarConfig, repository, gitInfo).get();
-      } catch (JsonProcessingException e) {
+      } catch (NonRetryableBuildException e) {
         LOG.warn("Error parsing config at path {} for repository {}@{}", blazarConfig, gitInfo.getFullRepositoryName(), gitInfo.getBranch());
         malformedFiles.add(new MalformedFile(gitInfo.getId().get(), "config", blazarConfig, Throwables.getStackTraceAsString(e)));
         continue;

--- a/BlazarService/src/main/java/com/hubspot/blazar/exception/NonRetryableBuildException.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/exception/NonRetryableBuildException.java
@@ -1,12 +1,12 @@
 package com.hubspot.blazar.exception;
 
-public class NonRetryableBuildException extends Exception {
+public class NonRetryableBuildException extends RuntimeException {
 
   public NonRetryableBuildException(String message) {
     super(message);
   }
 
-  public NonRetryableBuildException(String message, Exception e) {
-    super(message, e);
+  public NonRetryableBuildException(String message, Throwable t) {
+    super(message, t);
   }
 }

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/GitHubStatusVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/GitHubStatusVisitor.java
@@ -1,6 +1,5 @@
 package com.hubspot.blazar.listener;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.Map;
 
@@ -59,13 +58,7 @@ public class GitHubStatusVisitor implements RepositoryBuildVisitor {
     String sha = build.getSha().get();
     String description = getStateDescription(build.getState());
 
-    final GHRepository repository;
-    try {
-      repository = gitHubHelper.repositoryFor(gitInfo);
-    } catch (FileNotFoundException e) {
-      LOG.warn("Couldn't find repository {}", gitInfo.getFullRepositoryName(), e);
-      return;
-    }
+    GHRepository repository = gitHubHelper.repositoryFor(gitInfo);
 
     LOG.info("Setting status of commit {} to {} for build {}", sha, state, build.getId().get());
     try {

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectModuleBuildVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectModuleBuildVisitor.java
@@ -26,7 +26,6 @@ import com.hubspot.blazar.data.service.InterProjectBuildService;
 import com.hubspot.blazar.data.service.ModuleBuildService;
 import com.hubspot.blazar.data.service.ModuleService;
 import com.hubspot.blazar.data.service.RepositoryBuildService;
-import com.hubspot.blazar.exception.NonRetryableBuildException;
 
 public class InterProjectModuleBuildVisitor extends AbstractModuleBuildVisitor {
   private static final Logger LOG = LoggerFactory.getLogger(InterProjectModuleBuildVisitor.class);
@@ -143,7 +142,7 @@ public class InterProjectModuleBuildVisitor extends AbstractModuleBuildVisitor {
   }
 
   // Canceling
-  private void cancelSubTree(ModuleBuild build) throws NonRetryableBuildException {
+  private void cancelSubTree(ModuleBuild build) {
     InterProjectBuildMapping mapping = interProjectBuildMappingService.getByModuleBuildId(build.getId().get()).get();
     LOG.info("Found mapping {} corresponding to moduleBuild {}", mapping, build.getId());
     InterProjectBuild interProjectBuild = interProjectBuildService.getWithId(mapping.getInterProjectBuildId()).get();

--- a/BlazarService/src/main/java/com/hubspot/blazar/queue/QueueProcessor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/queue/QueueProcessor.java
@@ -23,6 +23,8 @@ import com.google.common.collect.Sets;
 import com.google.inject.name.Named;
 import com.hubspot.blazar.data.dao.QueueItemDao;
 import com.hubspot.blazar.data.queue.QueueItem;
+import com.hubspot.blazar.data.service.InterProjectBuildService;
+import com.hubspot.blazar.data.service.RepositoryBuildService;
 import com.hubspot.blazar.util.ManagedScheduledExecutorServiceProvider;
 
 import io.dropwizard.lifecycle.Managed;
@@ -32,6 +34,8 @@ public class QueueProcessor implements LeaderLatchListener, Managed, Runnable {
   private static final Logger LOG = LoggerFactory.getLogger(QueueProcessor.class);
 
   private final ScheduledExecutorService executorService;
+  private final RepositoryBuildService repositoryBuildService;
+  private final InterProjectBuildService interProjectBuildService;
   private final Map<String, ScheduledExecutorService> queueExecutors;
   private final QueueItemDao queueItemDao;
   private final SqlEventBus eventBus;
@@ -44,9 +48,13 @@ public class QueueProcessor implements LeaderLatchListener, Managed, Runnable {
   @Inject
   public QueueProcessor(@Named("QueueProcessor") ScheduledExecutorService executorService,
                         QueueItemDao queueItemDao,
+                        RepositoryBuildService repositoryBuildService,
+                        InterProjectBuildService interProjectBuildService,
                         SqlEventBus eventBus,
                         Set<Object> erroredItems) {
     this.executorService = executorService;
+    this.repositoryBuildService = repositoryBuildService;
+    this.interProjectBuildService = interProjectBuildService;
     this.queueExecutors = new ConcurrentHashMap<>();
     this.queueItemDao = queueItemDao;
     this.eventBus = eventBus;


### PR DESCRIPTION
Previously all calls to GitHubHelper had to handle GitHub Exceptions on
their own. Spreading error handling around like this makes things more
complicated than they need to be, because most times the error means
something cannot be retried anyway (missing file, GitHub is down etc.)

@gchomatas 

