### PR TITLE
Make alert close button more visible. Add help text explaining active modules.

### DIFF
--- a/BlazarUI/app/scripts/components/branch-state/BranchState.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/BranchState.jsx
@@ -142,7 +142,6 @@ class BranchState extends Component {
       loadingBranchStatus,
       activeModules,
       inactiveModules,
-      selectedModuleId,
       branchId,
       dismissBetaNotification,
       showBetaFeatureAlert,
@@ -169,6 +168,7 @@ class BranchState extends Component {
         <Tabs id="branch-state-tabs" className="branch-state-tabs" defaultActiveKey="active-modules">
           <Tab eventKey="active-modules" title="Active modules">
             <section id="active-modules">
+              <p className="text-muted">Showing the current build state for each module in this branch.</p>
               <ModuleList
                 modules={this.sortModules(activeModules)}
                 onCancelBuild={this.refreshBranchModuleStates}

--- a/BlazarUI/app/stylus/vendor-overrides/bootstrap-overrides.styl
+++ b/BlazarUI/app/stylus/vendor-overrides/bootstrap-overrides.styl
@@ -59,6 +59,9 @@ label
 .tooltip-inner, .popover-content
   color $color-gypsum
 
+.close
+  opacity 0.8
+
 // For now, scope these overrides to new pages to avoid breaking existing
 // designs. This is not ideal because it causes some specificity issues
 // and we should settle on a consistent set of bootstrap overrides


### PR DESCRIPTION
Before:
<img width="1139" alt="screen shot 2016-12-07 at 5 05 57 pm" src="https://cloud.githubusercontent.com/assets/4141884/20988619/8758a400-bc9f-11e6-86c4-71ebdeee2c7a.png">


After:
<img width="1139" alt="screen shot 2016-12-07 at 4 55 57 pm" src="https://cloud.githubusercontent.com/assets/4141884/20988479/f4341f10-bc9e-11e6-8c4e-c5be7283c80e.png">

cc @markhazlewood @gchomatas 