### PR TITLE
Ungate branch state page

### DIFF
--- a/BlazarUI/app/scripts/actions/feedbackActions.js
+++ b/BlazarUI/app/scripts/actions/feedbackActions.js
@@ -2,7 +2,8 @@ import Reflux from 'reflux';
 import Feedback from '../models/Feedback';
 
 const FeedbackActions = Reflux.createActions([
-  { 'sendFeedback': {children: ['completed', 'failed']} }
+  { 'sendFeedback': {children: ['completed', 'failed']} },
+  'showFeedbackForm'
 ]);
 
 FeedbackActions.sendFeedback.listen(function onSendFeedback(payload) {

--- a/BlazarUI/app/scripts/components/Helpers.js
+++ b/BlazarUI/app/scripts/components/Helpers.js
@@ -268,9 +268,6 @@ export const canViewDetailedModuleBuildInfo = (module) => {
     && moduleState !== MODULE_BUILD_STATES.SKIPPED;
 };
 
-export const getBlazarModuleBuildPath = (branchId, buildNumber, moduleName) => {
-  return `/builds/branch/${branchId}/build/${buildNumber}/module/${moduleName}`;
-};
 
 export const getCurrentModuleBuild = (moduleState) => {
   return moduleState.get('inProgressModuleBuild') ||

--- a/BlazarUI/app/scripts/components/branch-state/BetaFeatureAlert.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/BetaFeatureAlert.jsx
@@ -1,20 +1,23 @@
 import React, { PropTypes } from 'react';
 import Alert from 'react-bootstrap/lib/Alert';
+import FeedbackActions from '../../actions/feedbackActions';
 
 const BetaFeatureAlert = ({onDismiss}) => {
+  const feedbackFormLink = <a onClick={FeedbackActions.showFeedbackForm}>get in touch</a>;
   return (
     <Alert bsStyle="info" onDismiss={onDismiss}>
       <h4>A new perspective on your project</h4>
       <p>
         This new  page combines information previously split among several other views
         to give you a concise, live view of the current build state for this branch.
-        Below you'll find the latest build information for each module, along
-        with information about any pending or in-progress builds and a historical record of
-        past module builds.
+        Below <strong>you'll find the latest build information for each module</strong>,
+        along with information about any pending or in-progress builds and a historical
+        record of past module builds.
       </p>
       <p>
-        Give it a spin! And as always if you have feedback please get in touch using the link at
-        the bottom of this page.
+        Give it a spin! And as always if you have feedback
+        please {feedbackFormLink} using the link at the bottom
+        of this page.
       </p>
     </Alert>
   );

--- a/BlazarUI/app/scripts/components/branch-state/BetaFeatureAlert.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/BetaFeatureAlert.jsx
@@ -4,15 +4,18 @@ import Alert from 'react-bootstrap/lib/Alert';
 const BetaFeatureAlert = ({onDismiss}) => {
   return (
     <Alert bsStyle="info" onDismiss={onDismiss}>
-      <h4>Beta - tell us what you think!</h4>
+      <h4>A new perspective on your project</h4>
       <p>
-        Your team has been selected as part of the initial rollout of a new
-        module-centric builds page. This page combines information from the
-        branch build history and build details pages to provide you with a
-        more relevant view of the current state of a branch. It will eventually
-        become the main page for accessing your builds.
+        This new  page combines information previously split among several other views
+        to give you a concise, live view of the current build state for this branch.
+        Below you'll find the latest build information for each module, along
+        with information about any pending or in-progress builds and a historical record of
+        past module builds.
       </p>
-      <p>We'd love to hear any feedback you have using the link at the bottom of this page.</p>
+      <p>
+        Give it a spin! And as always if you have feedback please get in touch using the link at
+        the bottom of this page.
+      </p>
     </Alert>
   );
 };

--- a/BlazarUI/app/scripts/components/branch-state/BranchState.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/BranchState.jsx
@@ -19,7 +19,8 @@ import FailingModuleBuildsAlert from './FailingModuleBuildsAlert.jsx';
 import MalformedFileNotification from '../shared/MalformedFileNotification.jsx';
 
 import ModuleBuildStates from '../../constants/ModuleBuildStates';
-import { getCurrentModuleBuild, getCurrentBranchBuild, getBlazarModuleBuildPath } from '../Helpers';
+import { getCurrentModuleBuild, getCurrentBranchBuild } from '../Helpers';
+import { getBranchStatePath, getModuleBuildPath } from '../../utils/blazarPaths';
 
 class BranchState extends Component {
   constructor(props) {
@@ -93,7 +94,7 @@ class BranchState extends Component {
         const {branchId} = this.props;
         const moduleBuildNumber = getCurrentModuleBuild(moduleState).get('buildNumber');
         const moduleName = moduleState.getIn(['module', 'name']);
-        const blazarPath = getBlazarModuleBuildPath(branchId, moduleBuildNumber, moduleName);
+        const blazarPath = getModuleBuildPath(branchId, moduleBuildNumber, moduleName);
         return failingModuleBuildBlazarPaths.set(moduleName, blazarPath);
       }, Immutable.Map());
   }
@@ -104,7 +105,7 @@ class BranchState extends Component {
   }
 
   handleBranchSelect(selectedBranchId) {
-    this.props.router.push(`/branches/${selectedBranchId}/state`);
+    this.props.router.push(getBranchStatePath(selectedBranchId));
     window.document.activeElement.blur();
   }
 

--- a/BlazarUI/app/scripts/components/branch-state/BranchStateHeadline.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/BranchStateHeadline.jsx
@@ -12,6 +12,7 @@ import Star from '../shared/Star.jsx';
 
 import { showBuildBranchModal } from '../../redux-actions/buildBranchFormActions';
 import { getBranchesInRepository } from '../../selectors';
+import { getBranchBuildHistoryPath, getBranchSettingsPath } from '../../utils/blazarPaths';
 
 class BranchStateHeadline extends Component {
   getFilteredBranchOptions() {
@@ -89,10 +90,10 @@ class BranchStateHeadline extends Component {
         </PageHeader>
         <div className="page-header__sub-header">
           <p className="branch-state-headline__sub-header-links">
-            <Link to={`/branches/${branchId}/builds`} className="build-history-link">
+            <Link to={getBranchBuildHistoryPath(branchId)} className="build-history-link">
               <Icon name="history" /> Branch build history
             </Link>
-            <Link to={`/settings/branch/${branchId}`} className="build-settings-link">
+            <Link to={getBranchSettingsPath(branchId)} className="build-settings-link">
               <Icon name="cog" /> Settings
             </Link>
           </p>

--- a/BlazarUI/app/scripts/components/branch-state/ModuleItemSummary.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/ModuleItemSummary.jsx
@@ -8,12 +8,13 @@ import Icon from '../shared/Icon.jsx';
 import ModuleBuildListItemWrapper from './shared/ModuleBuildListItemWrapper.jsx';
 
 import { getClassNameColorModifier } from '../../constants/ModuleBuildStates';
-import { canViewDetailedModuleBuildInfo, getBlazarModuleBuildPath } from '../Helpers';
+import { canViewDetailedModuleBuildInfo } from '../Helpers';
+import { getModuleBuildPath } from '../../utils/blazarPaths';
 
 const getBuildLogLink = (module, moduleBuild, branchBuild) => {
   if (canViewDetailedModuleBuildInfo(moduleBuild)) {
     const moduleName = module.get('name');
-    const linkPath = getBlazarModuleBuildPath(branchBuild.get('branchId'), moduleBuild.get('buildNumber'), moduleName);
+    const linkPath = getModuleBuildPath(branchBuild.get('branchId'), moduleBuild.get('buildNumber'), moduleName);
     return (
       <div className="module-item-summary__build-log-link-container">
         <Link to={linkPath} className="module-item-summary__build-log-link">View build log</Link>

--- a/BlazarUI/app/scripts/components/branch-state/module-build-history/ModuleBuildHistoryItem.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/module-build-history/ModuleBuildHistoryItem.jsx
@@ -7,7 +7,8 @@ import UsersForBuild from '../shared/UsersForBuild.jsx';
 import CommitsSummary from '../shared/CommitsSummary.jsx';
 import ModuleBuildListItemWrapper from '../shared/ModuleBuildListItemWrapper.jsx';
 
-import { canViewDetailedModuleBuildInfo, getBlazarModuleBuildPath } from '../../Helpers';
+import { canViewDetailedModuleBuildInfo } from '../../Helpers';
+import { getModuleBuildPath } from '../../../utils/blazarPaths';
 
 const renderBuildNumber = (moduleName, moduleBuild, branchBuild) => {
   const branchId = branchBuild.get('branchId');
@@ -15,7 +16,7 @@ const renderBuildNumber = (moduleName, moduleBuild, branchBuild) => {
   const formattedBuildNumber = `#${buildNumber}`;
 
   if (canViewDetailedModuleBuildInfo(moduleBuild)) {
-    const linkPath = getBlazarModuleBuildPath(branchId, buildNumber, moduleName);
+    const linkPath = getModuleBuildPath(branchId, buildNumber, moduleName);
     return (
       <Link to={linkPath} className="module-build-history-item__build-log-link">
         {formattedBuildNumber}

--- a/BlazarUI/app/scripts/components/branch/BranchContainer.jsx
+++ b/BlazarUI/app/scripts/components/branch/BranchContainer.jsx
@@ -23,6 +23,7 @@ import RepoActions from '../../actions/repoActions';
 import { showBuildBranchModal } from '../../redux-actions/buildBranchFormActions';
 
 import {getPreviousBuildState} from '../Helpers.js';
+import {getBranchSettingsPath} from '../../utils/blazarPaths';
 
 const initialState = {
   builds: null,
@@ -171,7 +172,7 @@ class BranchContainer extends Component {
       return null;
     }
 
-    const buildSettingsLink = `/settings/branch/${this.props.params.branchId}`;
+    const buildSettingsLink = getBranchSettingsPath(this.props.params.branchId);
 
     return (
       <Link to={buildSettingsLink}>

--- a/BlazarUI/app/scripts/components/branch/BranchHeadline.jsx
+++ b/BlazarUI/app/scripts/components/branch/BranchHeadline.jsx
@@ -1,12 +1,14 @@
 /* global config */
 import React, {Component, PropTypes} from 'react';
 import Select from 'react-select';
+import moment from 'moment';
+
 import Image from '../shared/Image.jsx';
 import Headline from '../shared/headline/Headline.jsx';
 import Star from '../shared/Star.jsx';
 import Icon from '../shared/Icon.jsx';
 import SimpleBreadcrumbs from '../shared/SimpleBreadcrumbs.jsx';
-import moment from 'moment';
+import { getBranchBuildHistoryPath } from '../../utils/blazarPaths';
 
 class BranchHeadline extends Component {
 
@@ -43,11 +45,7 @@ class BranchHeadline extends Component {
       return;
     }
 
-    const branchLink = `/builds/branch/${selected}`;
-    this.context.router.push({
-      pathname: branchLink,
-      state: {handlingBranchSelect: true}
-    });
+    this.context.router.push(getBranchBuildHistoryPath(selected));
   }
 
   getFilteredBranches() {

--- a/BlazarUI/app/scripts/components/repo-build/InterProjectAlert.jsx
+++ b/BlazarUI/app/scripts/components/repo-build/InterProjectAlert.jsx
@@ -5,6 +5,7 @@ import Alert from 'react-bootstrap/lib/Alert';
 import classNames from 'classnames';
 
 import {getInterProjectClassName, InterProjectBuildTypes} from '../../constants/InterProjectConstants';
+import { getBranchBuildByIdPath } from '../../utils/blazarPaths';
 
 class InterProjectAlert extends Component {
 
@@ -83,7 +84,7 @@ class InterProjectAlert extends Component {
     const repoBuildNodes = map(repoBuilds, (name, id) => {
       return (
         <li key={id}>
-          <Link to={`/builds/repo-build/${id}`}>
+          <Link to={getBranchBuildByIdPath(id)}>
             {this.filterHostAndOrg(name)}
           </Link>
         </li>
@@ -176,7 +177,7 @@ class InterProjectAlert extends Component {
     const {interProjectBuildId, rootRepoBuilds} = this.props.upAndDownstreamModules;
 
     const rootRepoBuildId = Object.keys(rootRepoBuilds)[0];
-    const triggeredBy = rootRepoBuildId ? <Link to={`/builds/repo-build/${rootRepoBuildId}`}>{this.filterHostAndOrg(rootRepoBuilds[rootRepoBuildId])}</Link> : 'this build';
+    const triggeredBy = rootRepoBuildId ? <Link to={getBranchBuildByIdPath(rootRepoBuildId)}>{this.filterHostAndOrg(rootRepoBuilds[rootRepoBuildId])}</Link> : 'this build';
 
     return (
       <div className="inter-project-alert__root-info">

--- a/BlazarUI/app/scripts/components/repo-build/RepoBuildDetail.jsx
+++ b/BlazarUI/app/scripts/components/repo-build/RepoBuildDetail.jsx
@@ -13,6 +13,8 @@ import BuildStates from '../../constants/BuildStates';
 import FINAL_BUILD_STATES from '../../constants/finalBuildStates';
 import {LABELS} from '../constants';
 
+import { getBranchStatePath } from '../../utils/blazarPaths';
+
 class RepoBuildDetail extends Component {
 
   constructor(props) {
@@ -32,8 +34,7 @@ class RepoBuildDetail extends Component {
 
   handleCancelBuild() {
     const {router, params: {branchId}} = this.props;
-    const branchHistoryPagePath = `/builds/branch/${branchId}`;
-    router.push(branchHistoryPagePath);
+    router.push(getBranchStatePath(branchId));
   }
 
   renderCommits() {

--- a/BlazarUI/app/scripts/components/shared/SimpleBreadcrumbs.jsx
+++ b/BlazarUI/app/scripts/components/shared/SimpleBreadcrumbs.jsx
@@ -2,17 +2,14 @@ import React, { Component, PropTypes } from 'react';
 import { Link } from 'react-router';
 
 import Icon from './Icon.jsx';
+import { getRepoPath, getBranchStatePath, getBranchBuildPath } from '../../utils/blazarPaths';
 
 class SimpleBreadcrumbs extends Component {
 
   getBuildNumber() {
     const {params, data} = this.props;
-
-    if (params.buildNumber !== 'latest') {
-      return params.buildNumber;
-    }
-
-    return data.build.buildNumber;
+    const getLatestBuildNumber = params.buildNumber === 'latest';
+    return getLatestBuildNumber ? data.build.buildNumber : params.buildNumber;
   }
 
   renderRepoCrumb() {
@@ -22,7 +19,7 @@ class SimpleBreadcrumbs extends Component {
       return null;
     }
 
-    const repoLink = `/builds/repo/${branchInfo.repository}`;
+    const repoLink = getRepoPath(branchInfo.repository);
 
     return (
       <span className="simple-breadcrumbs__repo">
@@ -38,7 +35,7 @@ class SimpleBreadcrumbs extends Component {
       return null;
     }
 
-    const branchLink = `/builds/branch/${params.branchId}`;
+    const branchLink = getBranchStatePath(params.branchId);
 
     return (
       <span className="simple-breadcrumbs__branch">
@@ -56,7 +53,7 @@ class SimpleBreadcrumbs extends Component {
     }
 
     const buildNumber = this.getBuildNumber();
-    const buildLink = `/builds/branch/${params.branchId}/build/${buildNumber}`;
+    const buildLink = getBranchBuildPath(params.branchId, buildNumber);
 
     return (
       <span className="simple-breadcrumbs__build">

--- a/BlazarUI/app/scripts/components/sidebar/SidebarItem.jsx
+++ b/BlazarUI/app/scripts/components/sidebar/SidebarItem.jsx
@@ -1,10 +1,13 @@
 import React, {Component, PropTypes} from 'react';
 import {Link} from 'react-router';
 import classnames from 'classnames';
-import {truncate} from '../Helpers.js';
+
 import Icon from '../shared/Icon.jsx';
-import BuildStates from '../../constants/BuildStates.js';
 import BuildStateIcon from '../shared/BuildStateIcon.jsx';
+import {truncate} from '../Helpers.js';
+
+import BuildStates from '../../constants/BuildStates.js';
+import { getRepoPath } from '../../utils/blazarPaths';
 
 class SidebarItem extends Component {
 
@@ -79,7 +82,7 @@ class SidebarItem extends Component {
 
   renderRepoLink() {
     const {repository} = this.props;
-    const blazarRepositoryPath = `/builds/repo/${repository}`;
+    const blazarRepositoryPath = getRepoPath(repository);
 
     return (
       <div className="sidebar-item__repo-link">

--- a/BlazarUI/app/scripts/data/BranchApi.js
+++ b/BlazarUI/app/scripts/data/BranchApi.js
@@ -1,12 +1,14 @@
 import Resource from '../services/ResourceProvider';
 import { fromJS } from 'immutable';
 import humanizeDuration from 'humanize-duration';
-import { getUsernameFromCookie } from '../components/Helpers.js';
 import $ from 'jquery';
+
+import { getUsernameFromCookie } from '../components/Helpers.js';
+import { getBranchBuildPath } from '../utils/blazarPaths';
 
 function _parse(params, resp) {
   const builds = resp.map((build) => {
-    build.blazarPath = `/builds/branch/${params.branchId}/build/${build.buildNumber}`;
+    build.blazarPath = getBranchBuildPath(params.branchId, build.buildNumber);
     if (build.endTimestamp && build.startTimestamp) {
       build.duration = humanizeDuration(build.endTimestamp - build.startTimestamp, {round: true});
     }

--- a/BlazarUI/app/scripts/data/BuildsApi.js
+++ b/BlazarUI/app/scripts/data/BuildsApi.js
@@ -3,6 +3,7 @@ import {has} from 'underscore';
 import humanizeDuration from 'humanize-duration';
 import PollingProvider from '../services/PollingProvider';
 import store from '../reduxStore';
+import { getRepoPath, getBranchBuildPath, getBranchStatePath } from '../utils/blazarPaths';
 
 function _groupBuilds(builds) {
   const starredBranchIds = store.getState().starredBranches;
@@ -21,18 +22,20 @@ function _parse(data) {
       inProgressBuild
     } = item;
 
+    const branchId = gitInfo.id;
+
     if (has(item, 'inProgressBuild')) {
       item.inProgressBuild.duration = humanizeDuration(Date.now() - item.inProgressBuild.startTimestamp, {round: true});
-      item.inProgressBuild.blazarPath = `/builds/branch/${gitInfo.id}/build/${inProgressBuild.buildNumber}`;
+      item.inProgressBuild.blazarPath = getBranchBuildPath(branchId, inProgressBuild.buildNumber);
     }
 
     if (has(item, 'lastBuild')) {
       item.lastBuild.duration = humanizeDuration(item.lastBuild.endTimestamp - item.lastBuild.startTimestamp, {round: true});
-      item.lastBuild.blazarPath = `/builds/branch/${gitInfo.id}/build/${lastBuild.buildNumber}`;
+      item.lastBuild.blazarPath = getBranchBuildPath(branchId, lastBuild.buildNumber);
     }
 
-    item.gitInfo.blazarRepositoryPath = `/builds/repo/${gitInfo.repository}`;
-    item.gitInfo.blazarBranchPath = `/builds/branch/${gitInfo.id}`;
+    item.gitInfo.blazarRepositoryPath = getRepoPath(gitInfo.repository);
+    item.gitInfo.blazarBranchPath = getBranchStatePath(branchId);
 
     return item;
   });

--- a/BlazarUI/app/scripts/data/RepoBuildApi.js
+++ b/BlazarUI/app/scripts/data/RepoBuildApi.js
@@ -5,6 +5,7 @@ import humanizeDuration from 'humanize-duration';
 
 import { getErrorMessage } from './apiUtils';
 import Resource from '../services/ResourceProvider';
+import { getModuleBuildPath } from '../utils/blazarPaths';
 
 function _parse(resp) {
   if (resp.startTimestamp && resp.endTimestamp) {
@@ -92,7 +93,7 @@ function fetchModuleBuildsById(branchId, repoBuildId, buildNumber) {
         const moduleInfo = findWhere(moduleInfos, {id: build.moduleId});
         const moduleInfoExtended = {
           name: moduleInfo.name,
-          blazarPath: `/builds/branch/${branchId}/build/${buildNumber}/module/${moduleInfo.name}`
+          blazarPath: getModuleBuildPath(branchId, buildNumber, moduleInfo.name)
         };
 
         return extend(build, moduleInfoExtended);

--- a/BlazarUI/app/scripts/reducers/dismissedBetaNotifications.js
+++ b/BlazarUI/app/scripts/reducers/dismissedBetaNotifications.js
@@ -5,7 +5,7 @@ const initialState = Immutable.Map({
   branchStatePage: false
 });
 
-export default function branch(state = initialState, action) {
+export default function dismissedBetaNotifications(state = initialState, action) {
   switch (action.type) {
     case ActionTypes.DISMISS_BRANCH_STATE_PAGE_BETA_NOTIFICATION:
       return state.set('branchStatePage', true);

--- a/BlazarUI/app/scripts/routes.js
+++ b/BlazarUI/app/scripts/routes.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { Route, IndexRoute } from 'react-router';
+import { Route, IndexRoute, Redirect } from 'react-router';
 import $ from 'jquery';
 
 // Pages
@@ -14,7 +14,7 @@ import RepoBuild from './pages/repoBuild.jsx';
 import NotFound from './pages/notFound.jsx';
 import BranchState from './components/branch-state/BranchStateContainer.jsx';
 
-import { isBetaUser } from './utils/user.js';
+import { getBranchBuildPath } from './utils/blazarPaths';
 
 function redirectRepoBuildShortlink(nextState, replace, callback) {
   const data = $.ajax({
@@ -24,7 +24,7 @@ function redirectRepoBuildShortlink(nextState, replace, callback) {
   });
 
   data.then((resp) => {
-    replace(`/builds/branch/${resp.branchId}/build/${resp.buildNumber}`);
+    replace(getBranchBuildPath(resp.branchId, resp.buildNumber));
     callback();
   }, () => {
     replace('/not-found');
@@ -32,19 +32,14 @@ function redirectRepoBuildShortlink(nextState, replace, callback) {
   });
 }
 
-function redirectBetaUsersToBranchStatePage(nextState, replace) {
-  const locationState = nextState.location.state || {};
-  if (isBetaUser && !locationState.handlingBranchSelect) {
-    replace(`/branches/${nextState.params.branchId}/state`);
-  }
-}
-
 const routes = (
   <Route name="app" path="/" component={App}>
     <IndexRoute name="dashboard" component={ Dashboard } />
+
     <Route name="host" path="/builds/org/:org" component={ Org } />
     <Route name="repo" path="/builds/repo/:repo" component={ Repo } />
-    <Route name="branch" path="/builds/branch/:branchId" component={ Branch } onEnter={redirectBetaUsersToBranchStatePage} />
+    <Redirect from="/builds/branch/:branchId" to="/branches/:branchId/state" />
+
     <Route name="settings" path="/settings/branch/:branchId" component={ Settings } />
     <Route name="repoBuild" path="/builds/branch/:branchId/build/:buildNumber" component={ RepoBuild } />
     <Route name="build" path="/builds/branch/:branchId/build/:buildNumber/module/:moduleName" component={ Build } />

--- a/BlazarUI/app/scripts/stores/feedbackStore.js
+++ b/BlazarUI/app/scripts/stores/feedbackStore.js
@@ -19,6 +19,13 @@ const FeedbackStore = Reflux.createStore({
       sent: false,
       sendError: error
     });
+  },
+
+  onShowFeedbackForm() {
+    this.trigger({
+      visible: true,
+      submitted: false
+    });
   }
 
 });

--- a/BlazarUI/app/scripts/utils/blazarPaths.js
+++ b/BlazarUI/app/scripts/utils/blazarPaths.js
@@ -1,0 +1,28 @@
+export const getModuleBuildPath = (branchId, buildNumber, moduleName) => {
+  return `/builds/branch/${branchId}/build/${buildNumber}/module/${moduleName}`;
+};
+
+export const getBranchBuildPath = (branchId, buildNumber) => {
+  return `/builds/branch/${branchId}/build/${buildNumber}`;
+};
+
+// a 'repo build' is actually a build of a branch of a repo
+export const getBranchBuildByIdPath = (branchBuildId) => {
+  return `/builds/repo-build/${branchBuildId}`;
+};
+
+export const getBranchBuildHistoryPath = (branchId) => {
+  return `/branches/${branchId}/builds`;
+};
+
+export const getBranchStatePath = (branchId) => {
+  return `/branches/${branchId}/state`;
+};
+
+export const getBranchSettingsPath = (branchId) => {
+  return `/settings/branch/${branchId}`;
+};
+
+export const getRepoPath = (repoId) => {
+  return `/builds/repo/${repoId}`;
+};

--- a/BlazarUI/app/stylus/vendor-overrides/bootstrap-overrides.styl
+++ b/BlazarUI/app/stylus/vendor-overrides/bootstrap-overrides.styl
@@ -13,6 +13,10 @@ $popover-bg ?= $color-calypso-light
 $popover-border-color ?= $color-calypso-light
 $popover-arrow-outer-color ?= $color-calypso-light
 
+$alert-border-radius ?= 3px
+$alert-info-bg ?= $color-calypso-light
+$alert-info-border ?= $color-calypso-medium
+
 $text-muted ?= $color-eerie
 
 @import 'bootstrap'
@@ -29,7 +33,6 @@ $text-muted ?= $color-eerie
   border-color #ccc
 
 .alert
-  border-radius $radius-standard
   margin-bottom 10px
 
 .btn


### PR DESCRIPTION
This change updates the urls for everyone to link to the new branch state page. There is no more check for beta vs non-beta users. Links have been updated everywhere so the only way to reach the old page is by clicking on the `Build History` link.

I updated the wording a little for the new feature alert. Here's what it currently says
<img width="1104" alt="screen shot 2016-12-08 at 5 45 51 pm" src="https://cloud.githubusercontent.com/assets/4141884/21030814/76bc3ba0-bd6e-11e6-82be-a4f597788d51.png">

cc @markhazlewood @gchomatas @jonathanwgoodwin 