### PR TITLE
Make malformed file notification clearer

### DIFF
--- a/BlazarUI/app/scripts/components/shared/MalformedFileNotification.jsx
+++ b/BlazarUI/app/scripts/components/shared/MalformedFileNotification.jsx
@@ -50,7 +50,7 @@ class MalformedFileNotification extends Component {
       `${numberOfFiles} malformed configuration files`;
 
     const toggleExpandLink = (
-      <a onClick={this.toggleExpanded}>
+      <a onClick={this.toggleExpanded} className="malformed-files__expand-details-link">
         {this.state.expanded ? 'hide' : 'show'} details
       </a>
     );

--- a/BlazarUI/app/scripts/components/shared/MalformedFileNotification.jsx
+++ b/BlazarUI/app/scripts/components/shared/MalformedFileNotification.jsx
@@ -1,7 +1,7 @@
 import React, {Component, PropTypes} from 'react';
-import Alert from 'react-bootstrap/lib/Alert';
+import Alert from './Alert.jsx';
+import Collapse from 'react-bootstrap/lib/Collapse';
 import json2html from 'json-to-html';
-import classNames from 'classnames';
 
 class MalformedFileNotification extends Component {
 
@@ -35,38 +35,38 @@ class MalformedFileNotification extends Component {
     });
   }
 
-  renderDetails() {
-    const numberOfFiles = this.props.malformedFiles.length;
-
-    return (
-      <div className="malformed-files__details">
-        This branch contains {numberOfFiles} malformed configuration file{numberOfFiles !== 1 && 's'}. You''ll need to correct these errors:
-        {this.renderConfigInfo()}
-      </div>
-    );
-  }
-
-  renderAlert() {
-    return (
-      <Alert bsStyle="danger" className={classNames('malformed-files__alert', {expanded: this.state.expanded})}>
-        One or more of your config files for this branch is malformed.
-        <a onClick={this.toggleExpanded} className="pull-right">{this.state.expanded ? 'hide' : 'show'} details</a>
-        {this.state.expanded && this.renderDetails()}
-      </Alert>
-    );
-  }
-
   render() {
-    if (this.props.loading || this.props.malformedFiles.length === 0) {
-      return (
-        <div />
-      );
+    const {loading, malformedFiles} = this.props;
+
+    if (loading || malformedFiles.length === 0) {
+      return null;
     }
 
+    const numberOfFiles = malformedFiles.length;
+    const singular = numberOfFiles === 1;
+    const alertTitle = `Malformed build configuration file${singular ? '' : 's'}`;
+    const pluralizedFiles = singular ?
+      'a malformed configuration file' :
+      `${numberOfFiles} malformed configuration files`;
+
+    const toggleExpandLink = (
+      <a onClick={this.toggleExpanded}>
+        {this.state.expanded ? 'hide' : 'show'} details
+      </a>
+    );
+
     return (
-      <div className="malformed-files">
-        {this.renderAlert()}
-      </div>
+      <Alert type="danger" iconName="exclamation" titleText={alertTitle} className="malformed-files__alert">
+        <p>
+          Some modules in this branch are not being correctly detected by Blazar due
+          to {pluralizedFiles}. {toggleExpandLink}
+        </p>
+        <Collapse in={this.state.expanded}>
+          <div className="malformed-files__details">
+            {this.renderConfigInfo()}
+          </div>
+        </Collapse>
+      </Alert>
     );
   }
 }

--- a/BlazarUI/app/stylus/components/alert.styl
+++ b/BlazarUI/app/stylus/components/alert.styl
@@ -32,6 +32,7 @@
 
 .new-alert__content
   flex-grow 1
+  min-width 0
 
 .new-alert__title
   font-size 16px

--- a/BlazarUI/app/stylus/components/malformed-file-notification.styl
+++ b/BlazarUI/app/stylus/components/malformed-file-notification.styl
@@ -1,3 +1,11 @@
+.malformed-files__alert
+  position relative
+
+.malformed-files__expand-details-link
+  position absolute
+  top 10px
+  right 10px
+
 .malformed-files__file
   padding 10px 0
 

--- a/BlazarUI/app/stylus/components/malformed-file-notification.styl
+++ b/BlazarUI/app/stylus/components/malformed-file-notification.styl
@@ -1,19 +1,5 @@
-.malformed-files__alert
-  margin-top 8px
-  max-height 52px
-  transition max-height 1s ease
-  overflow hidden
-
-  &.expanded
-    max-height 999px
-
-.malformed-files__details
-  margin-top 20px
-
 .malformed-files__file
-  padding 10px
+  padding 10px 0
 
 .malformed-files__file-contents
   margin-top 5px
-  max-height 300px
-  overflow-y scroll


### PR DESCRIPTION
- Make malformed file alert stand out more by adding an icon and an alert title
- Update alert message to explicitly state that this error affects Blazar's module discovery process
- Remove nested vertical scrolling for malformed file contents (scroll bar is not obvious and user
  has already clicked to expand the alert)

<img width="957" alt="screen shot 2016-12-15 at 9 38 23 pm" src="https://cloud.githubusercontent.com/assets/4141884/21250004/ed5e779a-c30f-11e6-81c8-dbe5429b2b22.png">
<img width="950" alt="screen shot 2016-12-15 at 9 38 40 pm" src="https://cloud.githubusercontent.com/assets/4141884/21250005/ed642e6a-c30f-11e6-822d-780b1cc1c1ed.png">


cc @markhazlewood @jonathanwgoodwin