### PR TITLE
Moved + resized star button on the branch state page header

### DIFF
--- a/BlazarUI/app/scripts/components/branch-state/BranchStateHeadline.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/BranchStateHeadline.jsx
@@ -41,7 +41,6 @@ class BranchStateHeadline extends Component {
         <Button id="build-now-button" bsStyle="primary" onClick={this.props.showBuildBranchModal}>
           Build now
         </Button>
-        <Star className="branch-state-headline__star" branchId={this.props.branchId} />
       </div>
     );
   }
@@ -53,6 +52,7 @@ class BranchStateHeadline extends Component {
     const value = this.props.branchInfo.branch;
     return (
       <div className="branch-state-headline__branch-select">
+        <Star className="branch-state-headline__star" branchId={this.props.branchId} />
         <Icon type="octicon" name="git-branch" classNames="headline-icon" />
         <Select
           key={value}

--- a/BlazarUI/app/stylus/page/branch-state.styl
+++ b/BlazarUI/app/stylus/page/branch-state.styl
@@ -21,20 +21,17 @@
   align-items center
 
 .branch-state-headline__star
-  margin-left 20px
-  margin-right 15px
-  font-size 28px
+  font-size 1.25em
 
 .branch-state-headline__branch-select
   font-size 14px
   margin-top 8px
-  margin-left 34px
   position relative
 
   .branch-select-input
     font-size 16px
-    top -9px
-    left 16px
+    top -4px
+    left 40px
     width 350px
 
     & .Select-placeholder

--- a/BlazarUI/app/stylus/type.styl
+++ b/BlazarUI/app/stylus/type.styl
@@ -50,6 +50,7 @@ td
 
 .headline-icon
   margin-right 10px
+  margin-left 10px
   color #bbb
 
 .notfound__heading


### PR DESCRIPTION
Moved the star button/icon next to the branch name so that it's clear the branch is being starred and not the whole repo.