### PR TITLE
Fix sorting of modules when the dependency graph changes between branch builds

### DIFF
--- a/BlazarUI/app/scripts/components/branch-state/ModuleList.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/ModuleList.jsx
@@ -6,13 +6,36 @@ import ModuleItem from './ModuleItem.jsx';
 import { getCurrentBranchBuild, getCurrentModuleBuild } from '../Helpers';
 import { isComplete as isModuleBuildComplete } from '../../constants/ModuleBuildStates';
 
+const sortModules = (modules, branchBuild) => {
+  const topologicalSort = branchBuild.getIn(['dependencyGraph', 'topologicalSort']);
+
+  // gracefully handling old builds without topological sort info
+  if (!topologicalSort) {
+    return modules;
+  }
+
+  // sort by dependency order so that module builds proceed from top to bottom
+  return modules.sort((a, b) => {
+    const indexA = topologicalSort.indexOf(a.getIn(['module', 'id']));
+    const indexB = topologicalSort.indexOf(b.getIn(['module', 'id']));
+    return indexA - indexB;
+  });
+};
+
 const ModuleList = ({modules, onCancelBuild}) => {
   const modulesGroupedByCurrentBuild = modules.groupBy((moduleState) =>
     getCurrentBranchBuild(moduleState));
 
+  // reverse chronological order
+  const sortedBranchBuildEvents = modulesGroupedByCurrentBuild.keySeq().toList()
+    .sort((branchBuildA, branchBuildB) => {
+      return branchBuildB.get('buildNumber') - branchBuildA.get('buildNumber');
+    });
+
   return (
     <div>
-      {modulesGroupedByCurrentBuild.map((moduleStates, branchBuild) => {
+      {sortedBranchBuildEvents.map((branchBuild) => {
+        const moduleStates = sortModules(modulesGroupedByCurrentBuild.get(branchBuild), branchBuild);
         const buildNumber = branchBuild.get('buildNumber');
         const completedModuleBuildCount = moduleStates.count((moduleState) => {
           const currentModuleBuildState = getCurrentModuleBuild(moduleState).get('state');


### PR DESCRIPTION
Previously we were only sorting based on the dependency graph of the current
build for the first module, but different modules have have different
current branch builds. This change sorts the modules in each branch build
separately.

cc @jonathanwgoodwin 