### PR TITLE
Improve build status icons

### DIFF
--- a/BlazarUI/app/scripts/components/branch-state/BranchBuildHeader.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/BranchBuildHeader.jsx
@@ -6,7 +6,6 @@ import UsersForBuild from './shared/UsersForBuild.jsx';
 import CancelBuildButton from '../shared/branch-build/CancelBuildButton.jsx';
 import CommitsSummary from './shared/CommitsSummary.jsx';
 import BranchBuildProgress from './shared/BranchBuildProgress.jsx';
-import Icon from '../shared/Icon.jsx';
 
 import { isComplete } from '../../constants/BranchBuildStates';
 
@@ -21,7 +20,7 @@ const BranchBuildHeader = ({branchBuild, completedModuleBuildCount, totalNonSkip
   return (
     <div className="branch-build-header">
       <div className="branch-build-header__build-number">
-        {isActiveBuild && <Icon for="in-progress" classNames="branch-build-header__active-build-icon" />} #{buildNumber}
+        {isActiveBuild && <span className="branch-build-header__active-build-icon" />} #{buildNumber}
       </div>
       <div className="branch-build-header__build-summary">
         <BranchBuildProgress

--- a/BlazarUI/app/scripts/components/branch-state/BranchBuildHeader.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/BranchBuildHeader.jsx
@@ -21,7 +21,7 @@ const BranchBuildHeader = ({branchBuild, completedModuleBuildCount, totalNonSkip
   return (
     <div className="branch-build-header">
       <div className="branch-build-header__build-number">
-        {isActiveBuild && <Icon for="spinner" classNames="branch-build-header__active-build-icon" />} #{buildNumber}
+        {isActiveBuild && <Icon for="in-progress" classNames="branch-build-header__active-build-icon" />} #{buildNumber}
       </div>
       <div className="branch-build-header__build-summary">
         <BranchBuildProgress

--- a/BlazarUI/app/scripts/components/branch-state/shared/ModuleBuildStatus.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/shared/ModuleBuildStatus.jsx
@@ -5,6 +5,7 @@ import moment from 'moment';
 import Measure from 'react-measure';
 import ModuleBuildStates from '../../../constants/ModuleBuildStates';
 import Icon from '../../shared/Icon.jsx';
+import ProgressSpinner from '../../shared/ProgressSpinner.jsx';
 import BuildDuration from './BuildDuration.jsx';
 import BuildDurationStopwatch from './BuildDurationStopwatch.jsx';
 
@@ -16,7 +17,7 @@ const getIcon = (moduleBuildState) => {
 
     case ModuleBuildStates.LAUNCHING:
     case ModuleBuildStates.IN_PROGRESS:
-      return <Icon for="spinner" classNames="module-build-status__icon module-build-status__icon--info" />;
+      return <span className="module-build-status__icon"><ProgressSpinner /></span>;
 
     case ModuleBuildStates.SUCCEEDED:
       return <Icon name="check-circle" classNames="module-build-status__icon module-build-status__icon--success" />;

--- a/BlazarUI/app/scripts/components/branch-state/shared/ModuleBuildStatus.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/shared/ModuleBuildStatus.jsx
@@ -12,19 +12,20 @@ const getIcon = (moduleBuildState) => {
   switch (moduleBuildState) {
     case ModuleBuildStates.QUEUED:
     case ModuleBuildStates.WAITING_FOR_UPSTREAM_BUILD:
-      return <Icon name="clock-o" classNames="module-build-icon--info" />;
+      return <Icon name="clock-o" classNames="module-build-status__icon module-build-status__icon--info" />;
 
     case ModuleBuildStates.LAUNCHING:
     case ModuleBuildStates.IN_PROGRESS:
-      return <Icon for="spinner" classNames="module-build-icon--info" />;
+      return <Icon for="spinner" classNames="module-build-status__icon module-build-status__icon--info" />;
 
     case ModuleBuildStates.SUCCEEDED:
-      return <span className="status-circle status-circle--success" />;
+      return <Icon name="check-circle" classNames="module-build-status__icon module-build-status__icon--success" />;
+
     case ModuleBuildStates.FAILED:
-      return <span className="status-circle status-circle--failed" />;
+      return <Icon name="times-circle" classNames="module-build-status__icon module-build-status__icon--danger" />;
 
     case ModuleBuildStates.CANCELLED:
-      return <Icon name="ban" classNames="module-build-icon--warning" />;
+      return <Icon name="ban" classNames="module-build-status__icon module-build-status__icon--warning" />;
 
     default:
       return null;

--- a/BlazarUI/app/scripts/components/constants.js
+++ b/BlazarUI/app/scripts/components/constants.js
@@ -37,7 +37,8 @@ export const ICON_LIST = {
   'dashboard': 'fa fa-tachometer',
   'scroll-down': 'fa fa-arrow-circle-down',
   'scroll-up': 'fa fa-arrow-circle-up',
-  'circle-check': 'fa fa-check-circle'
+  'circle-check': 'fa fa-check-circle',
+  'in-progress': 'fa fa-circle fa-blink'
 };
 
 export const NO_MATCH_MESSAGES = {

--- a/BlazarUI/app/scripts/components/constants.js
+++ b/BlazarUI/app/scripts/components/constants.js
@@ -37,8 +37,7 @@ export const ICON_LIST = {
   'dashboard': 'fa fa-tachometer',
   'scroll-down': 'fa fa-arrow-circle-down',
   'scroll-up': 'fa fa-arrow-circle-up',
-  'circle-check': 'fa fa-check-circle',
-  'in-progress': 'fa fa-circle fa-blink'
+  'circle-check': 'fa fa-check-circle'
 };
 
 export const NO_MATCH_MESSAGES = {

--- a/BlazarUI/app/scripts/components/shared/ProgressSpinner.jsx
+++ b/BlazarUI/app/scripts/components/shared/ProgressSpinner.jsx
@@ -1,0 +1,5 @@
+import React from 'react';
+
+const ProgressSpinner = () => <span className="progress-spinner" />;
+
+export default ProgressSpinner;

--- a/BlazarUI/app/stylus/components/branch-state/branch-build-header.styl
+++ b/BlazarUI/app/stylus/components/branch-state/branch-build-header.styl
@@ -15,8 +15,17 @@
 .branch-build-header__active-build-icon
   position absolute
   left -20px
-  font-size 16px
-  color $color-calypso
+  height 16px
+  width 16px
+  border-radius 100%
+  background-color $color-calypso
+  animation active-build-icon-blink 1.5s linear infinite
+
+@keyframes active-build-icon-blink {
+  0% { opacity: 1; }
+  50% { opacity: 0; }
+  100% { opacity: 1; }
+}
 
 .branch-build-header__build-summary
   flex-grow 1

--- a/BlazarUI/app/stylus/components/branch-state/branch-build-header.styl
+++ b/BlazarUI/app/stylus/components/branch-state/branch-build-header.styl
@@ -21,11 +21,10 @@
   background-color $color-calypso
   animation active-build-icon-blink 1.5s linear infinite
 
-@keyframes active-build-icon-blink {
+@keyframes active-build-icon-blink
   0% { opacity: 1; }
   50% { opacity: 0; }
   100% { opacity: 1; }
-}
 
 .branch-build-header__build-summary
   flex-grow 1

--- a/BlazarUI/app/stylus/components/branch-state/module-build-status.styl
+++ b/BlazarUI/app/stylus/components/branch-state/module-build-status.styl
@@ -5,21 +5,18 @@
   color $color-eerie
   margin 0
 
-.status-circle
-  height 10px
-  width 10px
-  border-radius 50%
-  display inline-block
+.module-build-status__icon
+  font-size larger
   margin-right 5px
 
-.status-circle--success
-  background-color $color-oz
-
-.status-circle--failed
-  background-color $color-candy-apple
-
-.module-build-icon--info
+.module-build-status__icon--info
   color $color-calypso
 
-.module-build-icon--warning
+.module-build-status__icon--warning
   color $color-marigold-dark
+
+.module-build-status__icon--success
+  color $color-oz
+
+.module-build-status__icon--danger
+  color $color-candy-apple

--- a/BlazarUI/app/stylus/components/progress-spinner.styl
+++ b/BlazarUI/app/stylus/components/progress-spinner.styl
@@ -1,0 +1,16 @@
+@import '../variables'
+
+.progress-spinner
+  border 0.2em solid $color-koala
+  border-top-color $color-calypso
+  border-radius 50%
+  width 0.9em
+  height 0.9em
+  animation progress-spin 1.5s linear infinite
+  display inline-block
+
+@keyframes progress-spin
+  0%
+    transform rotate(0deg)
+  100%
+    transform rotate(360deg)

--- a/BlazarUI/app/stylus/helpers.styl
+++ b/BlazarUI/app/stylus/helpers.styl
@@ -5,16 +5,16 @@
 
 .roomy-x
   margin 0 5px
-  
+
 .roomy-xy
   margin 10px 10px
 
 .hoverable
   cursor pointer
-  
+
 .code
   font-family $monospace
-  
+
 .plain-list
   margin 0
   padding 0
@@ -22,7 +22,7 @@
   li
     margin 5px 0
     word-break: break-all
-    
+
 .pre-text
   font-family $monospace
   font-size 10px
@@ -38,3 +38,13 @@
 
 .text-right
   text-align right
+
+@keyframes fa-blink {
+  0% { opacity: 1; }
+  50% { opacity: 0; }
+  100% { opacity: 1; }
+}
+
+.fa-blink {
+  animation fa-blink 1.5s linear infinite
+}

--- a/BlazarUI/app/stylus/helpers.styl
+++ b/BlazarUI/app/stylus/helpers.styl
@@ -38,13 +38,3 @@
 
 .text-right
   text-align right
-
-@keyframes fa-blink {
-  0% { opacity: 1; }
-  50% { opacity: 0; }
-  100% { opacity: 1; }
-}
-
-.fa-blink {
-  animation fa-blink 1.5s linear infinite
-}

--- a/BlazarUI/app/stylus/main.styl
+++ b/BlazarUI/app/stylus/main.styl
@@ -50,6 +50,7 @@
 @import 'components/module-modal'
 @import 'components/muted-message'
 @import 'components/pagination'
+@import 'components/progress-spinner'
 @import 'components/react-typeahead'
 @import 'components/repo-branch-card'
 @import 'components/repo-listing'


### PR DESCRIPTION
Makes module build and branch build icons more visible on the branch state page

cc @markhazlewood @gchomatas @jonathanwgoodwin 

Updated failed and success icons (replaces red and green circles)
<img width="1078" alt="screen shot 2016-12-27 at 11 02 55 am" src="https://cloud.githubusercontent.com/assets/4141884/21503257/136f5608-cc24-11e6-95d3-0e33aedda6f3.png">

Spinner for in-progress module builds has been updated (1/4 of circle is highlighted instead of just using http://fontawesome.io/icon/circle-o-notch/)
![progressspinner](https://cloud.githubusercontent.com/assets/4141884/21503201/920c69e8-cc23-11e6-858d-9c3975d8faf8.gif)

In-progress branch builds now have a blinking circle (like Jenkins) instead of the same spinner as in-progress module builds
![progressspinner2](https://cloud.githubusercontent.com/assets/4141884/21503200/920a9dac-cc23-11e6-9a78-1ff128e34739.gif)
