### PR TITLE
Make failed and canceled module build history items more visible

### DIFF
--- a/BlazarUI/app/scripts/components/branch-state/module-build-history/ModuleBuildHistoryItem.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/module-build-history/ModuleBuildHistoryItem.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react';
 import {Link} from 'react-router';
+import classNames from 'classnames';
 
 import ModuleBuildStatus from '../shared/ModuleBuildStatus.jsx';
 import BuildTriggerLabel from '../shared/BuildTriggerLabel.jsx';
@@ -9,6 +10,7 @@ import ModuleBuildListItemWrapper from '../shared/ModuleBuildListItemWrapper.jsx
 
 import { canViewDetailedModuleBuildInfo } from '../../Helpers';
 import { getModuleBuildPath } from '../../../utils/blazarPaths';
+import { getClassNameColorModifier } from '../../../constants/ModuleBuildStates';
 
 const renderBuildNumber = (moduleName, moduleBuild, branchBuild) => {
   const branchId = branchBuild.get('branchId');
@@ -28,10 +30,15 @@ const renderBuildNumber = (moduleName, moduleBuild, branchBuild) => {
 };
 
 const ModuleBuildHistoryItem = ({moduleBuild, moduleName, branchBuild}) => {
+  const colorModifier = getClassNameColorModifier(moduleBuild.get('state'));
+  const divClassName = classNames('module-build-history-item', {
+    [`module-build-history-item--${colorModifier}`]: colorModifier
+  });
+
   return (
     <li>
       <ModuleBuildListItemWrapper moduleBuild={moduleBuild}>
-        <div className={"module-build-history-item"}>
+        <div className={divClassName}>
           <div className="module-build-history-item__build-number">
             {renderBuildNumber(moduleName, moduleBuild, branchBuild)}
           </div>

--- a/BlazarUI/app/stylus/components/branch-state/module-build-history.styl
+++ b/BlazarUI/app/stylus/components/branch-state/module-build-history.styl
@@ -9,7 +9,7 @@
     margin-bottom 20px
 
 .module-build-history__pagination
-  margin 0
+  margin-bottom 0
 
 .module-build-history__list
   padding-left 0

--- a/BlazarUI/app/stylus/components/branch-state/module-build-history.styl
+++ b/BlazarUI/app/stylus/components/branch-state/module-build-history.styl
@@ -36,6 +36,12 @@
   font-size 12px
   padding-left 10px
 
+.module-build-history-item--danger
+  background-color $color-norman-light
+
+.module-build-history-item--warning
+  background-color $color-marigold-light
+
 .module-build-history-item__build-number
   width 50px
   min-width 50px


### PR DESCRIPTION
Adds background color to make the failed/cancelled items stand out more. Users were commenting that the failed items were not visible enough, especially compared to the colored build trigger labels.

cc @markhazlewood @gchomatas @jonathanwgoodwin 

<img width="1081" alt="screen shot 2016-12-29 at 2 54 17 pm" src="https://cloud.githubusercontent.com/assets/4141884/21556639/0d1b0310-cdd7-11e6-9929-65366b0a0874.png">

The divisions between the list items look a bit weird when there are a bunch stacked together
<img width="1071" alt="screen shot 2016-12-29 at 2 55 08 pm" src="https://cloud.githubusercontent.com/assets/4141884/21556644/24d7784e-cdd7-11e6-834b-1994b81edb1d.png">
<img width="1090" alt="screen shot 2016-12-29 at 2 53 56 pm" src="https://cloud.githubusercontent.com/assets/4141884/21556650/2dc361e8-cdd7-11e6-8fe1-11f56bf8e83b.png">
