### PR TITLE
Alert users when the last build of a currently in-progress module failed

### DIFF
--- a/BlazarUI/app/scripts/components/branch-state/BranchState.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/BranchState.jsx
@@ -48,12 +48,12 @@ class BranchState extends Component {
   getFailingModuleBuilds(moduleStates) {
     return moduleStates
       .filter((moduleState) => {
-        const lastModuleBuild = moduleState.get('lastModuleBuild');
-        return lastModuleBuild && lastModuleBuild.get('state') === ModuleBuildStates.FAILED;
+        const lastNonSkippedModuleBuild = moduleState.get('lastNonSkippedModuleBuild');
+        return lastNonSkippedModuleBuild && lastNonSkippedModuleBuild.get('state') === ModuleBuildStates.FAILED;
       })
       .map((moduleState) => {
         const {branchId} = this.props;
-        const moduleBuildNumber = moduleState.getIn(['lastModuleBuild', 'buildNumber']);
+        const moduleBuildNumber = moduleState.getIn(['lastNonSkippedModuleBuild', 'buildNumber']);
         const moduleName = moduleState.getIn(['module', 'name']);
         const blazarModuleBuildPath = getModuleBuildPath(branchId, moduleBuildNumber, moduleName);
         return Immutable.Map({moduleName, moduleBuildNumber, blazarModuleBuildPath});

--- a/BlazarUI/app/scripts/components/branch-state/FailingModuleBuildsAlert.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/FailingModuleBuildsAlert.jsx
@@ -1,26 +1,34 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import ImmutablePropTypes from 'react-immutable-proptypes';
 import { Link } from 'react-router';
 import Alert from '../shared/Alert.jsx';
 
-const FailingModuleBuildsAlert = ({failingModuleBuildBlazarPaths}) => {
-  const numberOfFailingModules = failingModuleBuildBlazarPaths.size;
-  const heading = numberOfFailingModules === 1 ? 'A module build is failing' :
-    `${numberOfFailingModules} module builds are failing`;
+const FailingModuleBuildsAlert = ({failingModuleBuilds}) => {
+  const numberOfFailingModules = failingModuleBuilds.size;
+  const heading = numberOfFailingModules === 1 ? 'A module build has failed' :
+    `${numberOfFailingModules} module builds have failed`;
 
   return (
     <Alert className="failing-module-builds" type="danger" iconName="exclamation" titleText={heading}>
       <ul className="failing-module-builds__list">
-        {failingModuleBuildBlazarPaths.map((blazarModuleBuildPath, moduleName) =>
-          <li key={moduleName}><Link to={blazarModuleBuildPath}>{moduleName}</Link></li>
-        ).toArray()}
+        {failingModuleBuilds.toJS().map(({blazarModuleBuildPath, moduleName, moduleBuildNumber}) =>
+          <li key={moduleName}>
+            <Link to={blazarModuleBuildPath}>{moduleName} #{moduleBuildNumber}</Link>
+          </li>
+        )}
       </ul>
     </Alert>
   );
 };
 
 FailingModuleBuildsAlert.propTypes = {
-  failingModuleBuildBlazarPaths: ImmutablePropTypes.map
+  failingModuleBuilds: ImmutablePropTypes.listOf(
+    ImmutablePropTypes.contains({
+      moduleName: PropTypes.string,
+      moduleBuildNumber: PropTypes.number,
+      blazarModuleBuildPath: PropTypes.string
+    })
+  )
 };
 
 export default FailingModuleBuildsAlert;


### PR DESCRIPTION
Previously users were only presented with a failing module builds alert
if the current state of a module was failed. This meant that the alert
went away immediately when a new build of the module was triggered.
The alert should disappear only if the module has been successfully built.

*Build in-progress*
<img width="1137" alt="screen shot 2017-01-04 at 9 22 36 am" src="https://cloud.githubusercontent.com/assets/4141884/21652493/aa864d10-d261-11e6-90f8-b4af3217d5c1.png">

*Build complete with failures*
<img width="1139" alt="screen shot 2017-01-04 at 9 23 43 am" src="https://cloud.githubusercontent.com/assets/4141884/21652494/aa8658fa-d261-11e6-8a1a-08f569789a0f.png">

cc @markhazlewood @jonathanwgoodwin @gchomatas 