### PR TITLE
WIP: Improve context in sentries

### DIFF
--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/RepositoryBuild.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/RepositoryBuild.java
@@ -128,7 +128,7 @@ public class RepositoryBuild {
 
   @Override
   public String toString() {
-    return com.google.common.base.Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("id", id)
         .add("branchId", branchId)
         .add("buildNumber", buildNumber)

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/util/LogUtils.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/util/LogUtils.java
@@ -1,6 +1,9 @@
 package com.hubspot.blazar.data.util;
 
-import static org.slf4j.event.Level.*;
+import static org.slf4j.event.Level.DEBUG;
+import static org.slf4j.event.Level.INFO;
+import static org.slf4j.event.Level.WARN;
+import static org.slf4j.event.Level.ERROR;
 
 import org.slf4j.Logger;
 import org.slf4j.event.Level;

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/util/LogUtils.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/util/LogUtils.java
@@ -1,0 +1,111 @@
+package com.hubspot.blazar.data.util;
+
+import static org.slf4j.event.Level.*;
+
+import org.slf4j.Logger;
+import org.slf4j.event.Level;
+
+import com.hubspot.blazar.base.InterProjectBuild;
+import com.hubspot.blazar.base.ModuleBuild;
+import com.hubspot.blazar.base.RepositoryBuild;
+
+public class LogUtils {
+
+  private final Logger logger;
+
+  private static final String BRANCH_BUILD_CONTEXT_FORMAT_STRING = "During branch build %s";
+  private static final String MODULE_BUILD_CONTEXT_FORMAT_STRING = "During module build %s";
+  private static final String IPB_BUILD_CONTEXT_FORMAT_STRING = "During inter-project build %s";
+
+  public LogUtils(Logger logger) {
+    this.logger = logger;
+  }
+
+  private void doLog(Level level, String format, Object... arguments) {
+    switch (level) {
+      case DEBUG:
+        logger.debug(format, arguments);
+        break;
+      case INFO:
+        logger.info(format, arguments);
+        break;
+      case WARN:
+        logger.warn(format, arguments);
+        break;
+      case ERROR:
+        logger.error(format, arguments);
+        break;
+      default:
+        break;
+    }
+
+  }
+
+  // DEBUG
+  public void debug(String format, Object... arguments) {
+    doLog(WARN, format, arguments);
+  }
+
+  public void debug(ModuleBuild buildContext, String format, Object... arguments) {
+    doLog(DEBUG, String.format(MODULE_BUILD_CONTEXT_FORMAT_STRING, buildContext) + format, arguments);
+  }
+
+  public void debug(RepositoryBuild buildContext, String format, Object... arguments) {
+    doLog(DEBUG, String.format(BRANCH_BUILD_CONTEXT_FORMAT_STRING, buildContext) + format, arguments);
+  }
+
+  public void debug(InterProjectBuild buildContext, String format, Object... arguments) {
+    doLog(DEBUG, String.format(IPB_BUILD_CONTEXT_FORMAT_STRING, buildContext) + format, arguments);
+  }
+
+  // INFO
+  public void info(String format, Object... arguments) {
+    doLog(WARN, format, arguments);
+  }
+
+  public void info(ModuleBuild buildContext, String format, Object... arguments) {
+    doLog(INFO, String.format(MODULE_BUILD_CONTEXT_FORMAT_STRING, buildContext) + format, arguments);
+  }
+
+  public void info(RepositoryBuild buildContext, String format, Object... arguments) {
+    doLog(INFO, String.format(BRANCH_BUILD_CONTEXT_FORMAT_STRING, buildContext) + format, arguments);
+  }
+
+  public void info(InterProjectBuild buildContext, String format, Object... arguments) {
+    doLog(INFO, String.format(IPB_BUILD_CONTEXT_FORMAT_STRING, buildContext) + format, arguments);
+  }
+
+  // WARN
+  public void warn(String format, Object... arguments) {
+    doLog(WARN, format, arguments);
+  }
+
+  public void warn(ModuleBuild buildContext, String format, Object... arguments) {
+    doLog(WARN, String.format(MODULE_BUILD_CONTEXT_FORMAT_STRING, buildContext) + format, arguments);
+  }
+
+  public void warn(RepositoryBuild buildContext, String format, Object... arguments) {
+    doLog(WARN, String.format(BRANCH_BUILD_CONTEXT_FORMAT_STRING, buildContext) + format, arguments);
+  }
+
+  public void warn(InterProjectBuild buildContext, String format, Object... arguments) {
+    doLog(WARN, String.format(IPB_BUILD_CONTEXT_FORMAT_STRING, buildContext) + format, arguments);
+  }
+
+  // ERROR
+  public void error(String format, Object... arguments) {
+    doLog(WARN, format, arguments);
+  }
+
+  public void error(ModuleBuild buildContext, String format, Object... arguments) {
+    doLog(ERROR, String.format(MODULE_BUILD_CONTEXT_FORMAT_STRING, buildContext) + format, arguments);
+  }
+
+  public void error(RepositoryBuild buildContext, String format, Object... arguments) {
+    doLog(ERROR, String.format(BRANCH_BUILD_CONTEXT_FORMAT_STRING, buildContext) + format, arguments);
+  }
+
+  public void error(InterProjectBuild buildContext, String format, Object... arguments) {
+    doLog(ERROR, String.format(IPB_BUILD_CONTEXT_FORMAT_STRING, buildContext) + format, arguments);
+  }
+}

--- a/BlazarService/src/main/java/com/hubspot/blazar/queue/SqlEventBus.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/queue/SqlEventBus.java
@@ -1,17 +1,18 @@
 package com.hubspot.blazar.queue;
 
+import java.util.Set;
+
+import javax.inject.Inject;
+import javax.inject.Singleton;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import com.google.common.eventbus.EventBus;
 import com.google.common.eventbus.SubscriberExceptionContext;
 import com.google.common.eventbus.SubscriberExceptionHandler;
 import com.hubspot.blazar.data.dao.QueueItemDao;
 import com.hubspot.blazar.data.queue.QueueItem;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import javax.inject.Inject;
-import javax.inject.Singleton;
-import java.util.Set;
 
 @Singleton
 public class SqlEventBus extends EventBus {
@@ -24,9 +25,6 @@ public class SqlEventBus extends EventBus {
 
       @Override
       public void handleException(Throwable exception, SubscriberExceptionContext context) {
-        String className = context.getSubscriber().getClass().getSimpleName();
-        String methodName = context.getSubscriberMethod().getName();
-        LOG.error("Error calling subscriber method {}.{}", className, methodName, exception);
         erroredItems.add(context.getEvent());
       }
     });


### PR DESCRIPTION
This adds a blazar log utils that makes it easy to add build context
to your logs. The log Utils accept an additional argument (the build as
context) and then formats the log line with some additional data from the
build.

I also updated the BuildDispatcher to use this when logging so that when we get sentries from there the sentry will contain information about _what build_ it was that caused this.

Todo:
- [ ] include hostname in sentry. (So we know which log to get from singularity). 

Cc @gchomatas 