### PR TITLE
Show times for cancelled and skipped module builds

### DIFF
--- a/BlazarUI/app/scripts/components/branch-state/module-build-history/ModuleBuildHistoryItem.jsx
+++ b/BlazarUI/app/scripts/components/branch-state/module-build-history/ModuleBuildHistoryItem.jsx
@@ -43,7 +43,12 @@ const ModuleBuildHistoryItem = ({moduleBuild, moduleName, branchBuild}) => {
             {renderBuildNumber(moduleName, moduleBuild, branchBuild)}
           </div>
           <div className="module-build-history-item__status">
-            <ModuleBuildStatus moduleBuild={moduleBuild} noIcon={true} abbreviateUnitsBreakpoint={250} />
+            <ModuleBuildStatus
+              moduleBuild={moduleBuild}
+              branchBuildStartTimestamp={branchBuild.get('startTimestamp')}
+              noIcon={true}
+              abbreviateUnitsBreakpoint={250}
+            />
           </div>
           <div className="module-build-history-item__build-trigger-label">
             <BuildTriggerLabel buildTrigger={branchBuild.get('buildTrigger')} />

--- a/BlazarUI/app/scripts/data/BranchStateApi.js
+++ b/BlazarUI/app/scripts/data/BranchStateApi.js
@@ -16,6 +16,7 @@ function fetchModuleBuildHistory(moduleId, offset, pageSize) {
     'moduleBuildInfos.branchBuild.buildTrigger',
     'moduleBuildInfos.branchBuild.commitInfo',
     'moduleBuildInfos.branchBuild.id',
+    'moduleBuildInfos.branchBuild.startTimestamp',
     'remaining'
   ];
 


### PR DESCRIPTION
- Update module build statuses to displayu end time instead of start time
- Show build time for cancelled builds
- Show build time for skipped builds

New version
<img width="1020" alt="screen shot 2017-01-09 at 1 44 45 pm" src="https://cloud.githubusercontent.com/assets/4141884/21778657/4faa962a-d672-11e6-96e5-5b6503ce900e.png">

Previous version
<img width="1011" alt="screen shot 2017-01-09 at 1 45 10 pm" src="https://cloud.githubusercontent.com/assets/4141884/21778658/4fb22386-d672-11e6-9627-50ce0ba74d35.png">

cc @markhazlewood @gchomatas 