### PR TITLE
Fix extra <td> for debug mode

### DIFF
--- a/BlazarUI/app/scripts/components/repo-build/RepoBuildModulesTableRow.jsx
+++ b/BlazarUI/app/scripts/components/repo-build/RepoBuildModulesTableRow.jsx
@@ -64,9 +64,7 @@ class RepoBuildModulesTableRow extends Component {
     const {taskId} = this.props.data;
     if (isDebugMode() && taskId) {
       return (
-        <td>
-          <SingularityLink taskId={taskId} />
-        </td>
+        <SingularityLink taskId={taskId} />
       );
     }
 
@@ -100,8 +98,8 @@ class RepoBuildModulesTableRow extends Component {
         <td>
           {this.renderDuration()}
         </td>
-        {this.renderSingularityLink()}
         <td>
+          {this.renderSingularityLink()}
         </td>
       </tr>
     );


### PR DESCRIPTION
Fixes table row extending beyond table when viewing the branch build page in debug mode

<img width="1107" alt="screen shot 2017-01-20 at 1 28 09 pm" src="https://cloud.githubusercontent.com/assets/4141884/22160622/5725b326-df14-11e6-8990-63aad95793be.png">

cc @jonathanwgoodwin 