### PR TITLE
Fix fonts on dashboard and branch settings pages

### DIFF
--- a/BlazarUI/app/stylus/components/repo-branch-card.styl
+++ b/BlazarUI/app/stylus/components/repo-branch-card.styl
@@ -10,7 +10,7 @@ $bg-transition-duration = .15s
 $build-and-status-width = 80px
 
 .repo-branch-card-stack__zero-state
-  font-family HelveticaNeue-light
+  font-weight $font-light
   color $color-heffalump
   text-align center
   max-width 560px
@@ -20,7 +20,7 @@ $build-and-status-width = 80px
     margin-top 30px
     margin-bottom 20px
     font-size 20px
-    font-family HelveticaNeue-medium
+    font-weight $font-medium
 
   & p
     font-size 16px
@@ -33,7 +33,7 @@ $build-and-status-width = 80px
   border $border
   border-bottom 0
   color $color-heffalump
-  font-family HelveticaNeue-medium
+  font-weight $font-medium
   padding-left $build-and-status-width
   text-transform uppercase
 
@@ -102,7 +102,6 @@ $build-and-status-width = 80px
 
 .repo-branch-card__branch-and-build
   padding-top 4px
-  font-family HelveticaNeue-Light
   color $color-eerie
   overflow hidden
   white-space nowrap
@@ -110,7 +109,6 @@ $build-and-status-width = 80px
   max-width calc(100% - 15px)
 
 .repo-branch-card__branch
-  font-family HelveticaNeue
   color $color-heffalump
   background-color #eceef1
   padding 3px 7px
@@ -123,7 +121,7 @@ $build-and-status-width = 80px
     content '\f020  '
 
 .repo-branch-card__build-number
-  font-family HelveticaNeue-light
+  font-weight $font-light
   color $color-heffalump
 
 .repo-branch-card__last-build
@@ -137,13 +135,13 @@ $build-and-status-width = 80px
 
 .repo-branch-card__last-build-time
   color $color-heffalump
-  font-family HelveticaNeue-bold
+  font-weight $font-heavy
 
 .repo-branch-card__triggered-by
   width $details-width
   height 100%
   vertical-align middle
-  font-family HelveticaNeue-light
+  font-weight $font-light
   color $color-heffalump
   overflow hidden
   white-space nowrap
@@ -156,16 +154,16 @@ $build-and-status-width = 80px
   position relative
 
 .repo-branch-card__details-header
-  font-family HelveticaNeue-light
+  font-weight $font-light
   font-size 18px
   color $color-heffalump
 
   & .repo-branch-card__build-number
-    font-family HelveticaNeue
+    font-weight $font-normal
 
 .repo-branch-card__author
   color #425b76
-  font-family HelveticaNeue-medium
+  font-weight $font-medium
 
 .repo-branch-card__module-rows
   margin-top 20px
@@ -174,7 +172,7 @@ $build-and-status-width = 80px
 .repo-branch-card__expanded-author
   font-size 14px
   color #2965a8
-  font-family HelveticaNeue
+  font-weight $font-normal
   padding-left 20px
 
 .repo-branch-card__expanded-module-row

--- a/BlazarUI/app/stylus/page/settings.styl
+++ b/BlazarUI/app/stylus/page/settings.styl
@@ -1,7 +1,6 @@
 @import '../variables'
 
 .notifications
-  font-family HelveticaNeue
   width 800px
   height 800px
 
@@ -125,7 +124,7 @@
 
   & > span
     font-size 16px
-    font-family HelveticaNeue-Bold
+    font-weight $font-heavy
 
   & > p
     padding-top 10px
@@ -151,7 +150,7 @@
 
   & span
     color #425b76
-    font-family HelveticaNeue-Medium
+    font-weight $font-medium
 
 .notifications__delete-select-yes
   padding 2px 20px
@@ -224,7 +223,6 @@
   & p
     margin-top 5px
     width 100%
-    font-family HelveticaNeue
     font-size 20px
     color #cbd6e2
 
@@ -247,7 +245,6 @@
   padding-top 10px
 
   & > span
-    font-family HelveticaNeue
     font-size 16px
     color #425B76
     position absolute


### PR DESCRIPTION
Previously, fallback fonts were not being used

cc @markhazlewood 