### PR TITLE
Fix clean metadata

### DIFF
--- a/BlazarService/src/main/java/com/hubspot/blazar/command/CleanRepoMetadataCommand.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/command/CleanRepoMetadataCommand.java
@@ -2,19 +2,23 @@ package com.hubspot.blazar.command;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Set;
+import java.util.Stack;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.RejectedExecutionException;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 
 import net.sourceforge.argparse4j.inf.Namespace;
+import net.sourceforge.argparse4j.inf.Subparser;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.hubspot.blazar.base.GitInfo;
@@ -30,29 +34,61 @@ public class CleanRepoMetadataCommand extends ConfiguredCommand<BlazarConfigurat
   private static final String COMMAND_NAME = "clean_repo_metadata";
   private static final String COMMAND_DESC = "Finds repos no longer in the managed organizations and marks all branches as inactive";
   private static final Logger LOG = LoggerFactory.getLogger(CleanRepoMetadataCommand.class);
+  private static final String NOOP_FLAG = "noop";
   private final ExecutorService executorService;
 
   public CleanRepoMetadataCommand() {
     super(COMMAND_NAME, COMMAND_DESC);
-    this.executorService = new ThreadPoolExecutor(10, 10, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(3000));
+
+    final ThreadFactory threadFactory = new ThreadFactoryBuilder().setNameFormat("CleanupWorker-%d").setDaemon(true).build();
+    this.executorService = new ThreadPoolExecutor(10, 10, 0L, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>(3000), threadFactory);
   }
 
   @Override
-  protected void run(Bootstrap<BlazarConfiguration> bootstrap,
-                     Namespace namespace,
-                     BlazarConfiguration configuration) throws Exception {
+  public void configure(Subparser subparser) {
+    super.configure(subparser);
+    subparser.addArgument("-n", "--noop")
+        .dest(NOOP_FLAG)
+        .type(Boolean.class)
+        .help("Runs in noop mode; makes no changes to the database")
+        .setDefault(false);
+  }
+
+  @Override
+  protected void run(
+      Bootstrap<BlazarConfiguration> bootstrap,
+      Namespace namespace,
+      BlazarConfiguration configuration) throws Exception {
+
+    boolean noop = namespace.getBoolean(NOOP_FLAG);
     Injector injector = Guice.createInjector(new BaseCommandModule(bootstrap, configuration));
     try {
       GitHubHelper gitHubHelper = injector.getInstance(GitHubHelper.class);
       BranchService branchService = injector.getInstance(BranchService.class);
-      Set<GitInfo> branches = branchService.getAllActive();
+      Stack<GitInfo> branchStack = new Stack<>();
+      branchStack.addAll(branchService.getAllActive());
       Map<GitInfo, CompletableFuture<Void>> futures = new HashMap<>();
 
-      for (GitInfo branch : branches) {
-        futures.put(branch, CompletableFuture.runAsync(new GitBranchUpdater(branch, gitHubHelper, configuration, branchService), executorService));
+      LOG.info("Starting cleanup of {} active branches", branchStack.size());
+
+      while (!branchStack.isEmpty()) {
+        GitInfo branch = branchStack.pop();
+        GitBranchUpdater updater = new GitBranchUpdater(branch, gitHubHelper, configuration, branchService, noop);
+        try {
+          futures.put(branch, CompletableFuture.runAsync(updater, executorService));
+        } catch (RejectedExecutionException e) {
+          try {
+            LOG.debug("Execution rejected for {} waiting to re-submit", branch);
+            Thread.sleep(1500);
+            branchStack.push(branch);
+          } catch (InterruptedException ie) {
+            LOG.info("Interrupted while waiting for queue to drain");
+            throw e;
+          }
+        }
       }
 
-      for(Map.Entry<GitInfo, CompletableFuture<Void>> futureEntry : futures.entrySet()) {
+      for (Map.Entry<GitInfo, CompletableFuture<Void>> futureEntry : futures.entrySet()) {
         try {
           futureEntry.getValue().get();
         } catch (ExecutionException e) {

--- a/BlazarService/src/test/java/com/hubspot/blazar/service/GitBranchUpdaterTest.java
+++ b/BlazarService/src/test/java/com/hubspot/blazar/service/GitBranchUpdaterTest.java
@@ -124,7 +124,7 @@ public class GitBranchUpdaterTest extends BlazarServiceTestBase {
   }
 
   private GitBranchUpdater buildUpdater(GitInfo gitInfo) {
-    return new GitBranchUpdater(gitInfo, gitHubHelper, blazarConfiguration, branchService);
+    return new GitBranchUpdater(gitInfo, gitHubHelper, blazarConfiguration, branchService, false);
   }
 
   private GitInfo buildGitInfo(String uri) {


### PR DESCRIPTION
@gchomatas 

This fixes issues where the linked blocking queue was not blocking because the CompletableFutures doesn't try to use `submit` when asking for a task to be executed and was just throwing RejectedExecutionExceptions instead.

Also adds a `--noop` flag so that we can run this and see what is going to change.
