### PR TITLE
Fix Inter Project Build commit Resolution

### DIFF
--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildTrigger.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildTrigger.java
@@ -1,9 +1,9 @@
 package com.hubspot.blazar.base;
 
+import java.util.Objects;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-
-import java.util.Objects;
 
 public class BuildTrigger {
   public enum Type {
@@ -31,9 +31,8 @@ public class BuildTrigger {
     return new BuildTrigger(Type.BRANCH_CREATION, branch);
   }
 
-  public static BuildTrigger forInterProjectBuild(InterProjectBuild build) {
-    String rootRepoBranch = String.format("%d", build.getId().get());
-    return new BuildTrigger(Type.INTER_PROJECT, rootRepoBranch);
+  public static BuildTrigger forInterProjectBuild(long interProjectBuildId) {
+    return new BuildTrigger(Type.INTER_PROJECT, String.valueOf(interProjectBuildId));
   }
 
   public Type getType() {

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/github/GitHubApiError.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/github/GitHubApiError.java
@@ -1,0 +1,32 @@
+package com.hubspot.blazar.base.github;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GitHubApiError {
+
+  private final String resource;
+  private final String code;
+  private final String message;
+
+  @JsonCreator
+  public GitHubApiError(@JsonProperty("resource") String resource,
+                        @JsonProperty("code") String code,
+                        @JsonProperty("message") String message) {
+    this.resource = resource;
+    this.code = code;
+    this.message = message;
+  }
+
+  public String getResource() {
+    return resource;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+}

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/github/GitHubErrorResponse.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/github/GitHubErrorResponse.java
@@ -1,0 +1,33 @@
+package com.hubspot.blazar.base.github;
+
+import java.util.List;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+public class GitHubErrorResponse {
+  private final String message;
+  private final List<GitHubApiError> errors;
+  private final String documentationUrl;
+
+  @JsonCreator
+  public GitHubErrorResponse(@JsonProperty("message") String message,
+                             @JsonProperty("errors") List<GitHubApiError> errors,
+                             @JsonProperty("documentation_url") String documentationUrl) {
+    this.message = message;
+    this.errors = errors;
+    this.documentationUrl = documentationUrl;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+  public List<GitHubApiError> getErrors() {
+    return errors;
+  }
+
+  public String getDocumentationUrl() {
+    return documentationUrl;
+  }
+}

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/GitHubStatusVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/GitHubStatusVisitor.java
@@ -2,6 +2,7 @@ package com.hubspot.blazar.listener;
 
 import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.util.List;
 import java.util.Map;
 
 import org.kohsuke.github.GHCommitState;
@@ -9,10 +10,13 @@ import org.kohsuke.github.GHRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.google.inject.Singleton;
 import com.hubspot.blazar.base.GitInfo;
 import com.hubspot.blazar.base.RepositoryBuild;
+import com.hubspot.blazar.base.github.GitHubApiError;
+import com.hubspot.blazar.base.github.GitHubErrorResponse;
 import com.hubspot.blazar.base.visitor.RepositoryBuildVisitor;
 import com.hubspot.blazar.config.BlazarConfiguration;
 import com.hubspot.blazar.config.GitHubConfiguration;
@@ -23,6 +27,7 @@ import com.hubspot.blazar.util.GitHubHelper;
 @Singleton
 public class GitHubStatusVisitor implements RepositoryBuildVisitor {
   private static final Logger LOG = LoggerFactory.getLogger(GitHubStatusVisitor.class);
+  private static final String GITHUB_TOO_MANY_STATUSES_MESSAGE = "This SHA and context has reached the maximum number of statuses.";
 
   private final BranchService branchService;
   private Map<String, GitHubConfiguration> gitHubConfigurationMap;
@@ -71,6 +76,15 @@ public class GitHubStatusVisitor implements RepositoryBuildVisitor {
     try {
       repository.createCommitStatus(sha, state, url, description, "Blazar");
     } catch (IOException e) {
+      Optional<GitHubErrorResponse> gitHubErrorResponse = gitHubHelper.extractErrorResponseFromException(e);
+      // GitHub has a limit of 100 statuses you can post to a commit -- since we can't delete statuses we just swallow this error
+      if (gitHubErrorResponse.isPresent()) {
+        List<GitHubApiError> errors = gitHubErrorResponse.get().getErrors();
+        if (errors.stream().filter(er -> er.getMessage().contains(GITHUB_TOO_MANY_STATUSES_MESSAGE)).count() > 0) {
+          LOG.info("Commit {}#{} has too many statuses status posting failed.", gitInfo.getFullRepositoryName(), sha);
+          return;
+        }
+      }
       LOG.error("Error setting status of commit {} to {} for build {}", sha, state, build.getId().get(), e);
     }
   }

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/GitHubStatusVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/GitHubStatusVisitor.java
@@ -81,7 +81,7 @@ public class GitHubStatusVisitor implements RepositoryBuildVisitor {
       if (gitHubErrorResponse.isPresent()) {
         List<GitHubApiError> errors = gitHubErrorResponse.get().getErrors();
         if (errors.stream().filter(er -> er.getMessage().contains(GITHUB_TOO_MANY_STATUSES_MESSAGE)).count() > 0) {
-          LOG.info("Commit {}#{} has too many statuses status posting failed.", gitInfo.getFullRepositoryName(), sha);
+          LOG.warn("Commit {}#{} has the maximum number of statuses GitHub allows, cannot post status.", gitInfo.getFullRepositoryName(), sha);
           return;
         }
       }

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectBuildHandler.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectBuildHandler.java
@@ -98,7 +98,7 @@ public class InterProjectBuildHandler extends AbstractInterProjectBuildVisitor {
 
     for (Map.Entry<Integer, Collection<Integer>> entry : branchToLaunchableModules.entrySet()) {
       Set<Integer> moduleIds = ImmutableSet.copyOf(entry.getValue());
-      BuildTrigger buildTrigger = BuildTrigger.forInterProjectBuild(build);
+      BuildTrigger buildTrigger = BuildTrigger.forInterProjectBuild(build.getId().get());
       BuildOptions buildOptions = new BuildOptions(moduleIds, BuildOptions.BuildDownstreams.NONE, false);
       GitInfo gitInfo = branchService.get(entry.getKey()).get();
       long buildId = repositoryBuildService.enqueue(gitInfo, buildTrigger, buildOptions);

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectModuleBuildVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/InterProjectModuleBuildVisitor.java
@@ -104,7 +104,7 @@ public class InterProjectModuleBuildVisitor extends AbstractModuleBuildVisitor {
     for (Map.Entry<Integer, Set<Integer>> entry : Multimaps.asMap(launchableBranchToModuleMap).entrySet()) {
       Set<Integer> launchableModules = entry.getValue();
       GitInfo gitInfo = branchService.get(entry.getKey()).get();
-      BuildTrigger buildTrigger = BuildTrigger.forInterProjectBuild(interProjectBuild);
+      BuildTrigger buildTrigger = BuildTrigger.forInterProjectBuild(interProjectBuild.getId().get());
       BuildOptions buildOptions = new BuildOptions(launchableModules, BuildOptions.BuildDownstreams.NONE, false);
       long buildId = repositoryBuildService.enqueue(gitInfo, buildTrigger, buildOptions);
       for (Integer moduleId : launchableModules) {

--- a/BlazarService/src/main/java/com/hubspot/blazar/util/GitHubHelper.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/util/GitHubHelper.java
@@ -32,6 +32,7 @@ import com.google.common.net.UrlEscapers;
 import com.hubspot.blazar.base.BuildConfig;
 import com.hubspot.blazar.base.CommitInfo;
 import com.hubspot.blazar.base.GitInfo;
+import com.hubspot.blazar.base.github.GitHubErrorResponse;
 import com.hubspot.blazar.github.GitHubProtos.Commit;
 import com.hubspot.blazar.github.GitHubProtos.User;
 
@@ -163,6 +164,15 @@ public class GitHubHelper {
     }
 
     return builder.build();
+  }
+
+
+  public Optional<GitHubErrorResponse> extractErrorResponseFromException(Throwable t) {
+    try {
+      return Optional.of(mapper.readValue(t.getMessage(), GitHubErrorResponse.class));
+    } catch (IOException e){
+      return Optional.absent();
+    }
   }
 
   private static User toAuthor(GHCommit commit) throws IOException {

--- a/BlazarService/src/test/java/com/hubspot/blazar/util/RepositoryBuildLauncherTest.java
+++ b/BlazarService/src/test/java/com/hubspot/blazar/util/RepositoryBuildLauncherTest.java
@@ -70,7 +70,7 @@ public class RepositoryBuildLauncherTest {
 
     when(gitHubHelper.shaFor(any(), any())).thenThrow(new IllegalStateException("Previous build is present this should not be called"));
 
-    launcher.commitInfo(branch, currentBuild, previousBuildOptional);
+    launcher.calculateCommitInfoForBuild(branch, currentBuild, previousBuildOptional);
   }
 
   @Test
@@ -124,6 +124,6 @@ public class RepositoryBuildLauncherTest {
     }).when(gitHubHelper).commitInfoFor(any(), any(), any());
 
 
-    launcher.commitInfo(branch, currentBuild, previousBuildOptional);
+    launcher.calculateCommitInfoForBuild(branch, currentBuild, previousBuildOptional);
   }
 }

--- a/BlazarService/src/test/java/com/hubspot/blazar/util/RepositoryBuildLauncherTest.java
+++ b/BlazarService/src/test/java/com/hubspot/blazar/util/RepositoryBuildLauncherTest.java
@@ -1,0 +1,129 @@
+package com.hubspot.blazar.util;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Collections;
+
+import org.jukito.JukitoRunner;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.kohsuke.github.GHCommit;
+import org.kohsuke.github.GHRepository;
+
+import com.google.common.base.Optional;
+import com.google.common.collect.ImmutableSet;
+import com.hubspot.blazar.base.BuildOptions;
+import com.hubspot.blazar.base.BuildTrigger;
+import com.hubspot.blazar.base.CommitInfo;
+import com.hubspot.blazar.base.GitInfo;
+import com.hubspot.blazar.base.RepositoryBuild;
+import com.hubspot.blazar.data.service.BranchService;
+import com.hubspot.blazar.data.service.DependenciesService;
+import com.hubspot.blazar.data.service.ModuleDiscoveryService;
+import com.hubspot.blazar.data.service.ModuleService;
+import com.hubspot.blazar.data.service.RepositoryBuildService;
+import com.hubspot.blazar.discovery.ModuleDiscovery;
+import com.hubspot.blazar.github.GitHubProtos.Commit;
+
+@RunWith(JukitoRunner.class)
+public class RepositoryBuildLauncherTest {
+
+  private final RepositoryBuildService repositoryBuildService = mock(RepositoryBuildService.class);
+  private final BranchService branchService = mock(BranchService.class);
+  private final ModuleService moduleService = mock(ModuleService.class);
+  private final DependenciesService dependenciesService = mock(DependenciesService.class);
+  private final ModuleDiscoveryService moduleDiscoveryService = mock(ModuleDiscoveryService.class);
+  private final ModuleDiscovery moduleDiscovery = mock(ModuleDiscovery.class);
+  private final GitHubHelper gitHubHelper = mock(GitHubHelper.class);
+
+  @Test
+  public void itUsesPreviousCommitWhenBuildIsPartOfInterProjectBuild() throws Exception {
+    GitInfo branch = new GitInfo(Optional.of(1), "git.example.com", "example", "repository", 1, "master", true, 0L, 1L);
+
+    String commitSha = "0000000000000000000000000000000000000000";
+    Commit commit = Commit.newBuilder().setId(commitSha).build();
+    CommitInfo commitInfo = new CommitInfo(commit, Optional.absent(), Collections.emptyList(), false);
+
+    RepositoryBuild previousBuild = RepositoryBuild.newBuilder(1, 1, RepositoryBuild.State.SUCCEEDED, BuildTrigger.forCommit(commitSha), BuildOptions.defaultOptions())
+        .setCommitInfo(Optional.of(commitInfo))
+        .build();
+    Optional<RepositoryBuild> previousBuildOptional = Optional.of(previousBuild);
+
+    BuildOptions ipbBuildOptions = new BuildOptions(ImmutableSet.of(1), BuildOptions.BuildDownstreams.NONE, false);
+    RepositoryBuild currentBuild = RepositoryBuild.queuedBuild(branch, BuildTrigger.forInterProjectBuild(1), 2, ipbBuildOptions);
+
+    RepositoryBuildLauncher launcher = new RepositoryBuildLauncher(repositoryBuildService, branchService, moduleService, dependenciesService, moduleDiscoveryService, moduleDiscovery, gitHubHelper);
+
+    doAnswer(invocation -> {
+      Commit currentCommit = (Commit) invocation.getArguments()[1];
+      Optional<Commit> previousCommit = (Optional<Commit>) invocation.getArguments()[2];
+      assertThat(currentCommit.getId()).isEqualTo(commitSha);
+      assertThat(previousCommit.isPresent()).isTrue();
+      assertThat(previousCommit.get().getId()).isEqualTo(commitSha);
+      return null;
+    }).when(gitHubHelper).commitInfoFor(any(), any(), any());
+
+    when(gitHubHelper.shaFor(any(), any())).thenThrow(new IllegalStateException("Previous build is present this should not be called"));
+
+    launcher.commitInfo(branch, currentBuild, previousBuildOptional);
+  }
+
+  @Test
+  public void itUsesNewCommitWhenBranchBuildIsNotPartOfAInterProjectBuild() throws Exception {
+    GitInfo branch = new GitInfo(Optional.of(1), "git.example.com", "example", "repository", 1, "master", true, 0L, 1L);
+
+    String initialCommitSha = "0000000000000000000000000000000000000000";
+    String secondCommitSha = "1111111111111111111111111111111111111111";
+
+    Commit initialCommit = Commit.newBuilder().setId(initialCommitSha).build();
+
+    CommitInfo previousCommitInfo = new CommitInfo(initialCommit, Optional.absent(), Collections.emptyList(), false);
+    RepositoryBuild previousBuild = RepositoryBuild.newBuilder(1, 1, RepositoryBuild.State.SUCCEEDED, BuildTrigger.forCommit(initialCommitSha), BuildOptions.defaultOptions())
+        .setCommitInfo(Optional.of(previousCommitInfo))
+        .build();
+    Optional<RepositoryBuild> previousBuildOptional = Optional.of(previousBuild);
+
+
+    RepositoryBuild currentBuild = RepositoryBuild.queuedBuild(branch, BuildTrigger.forCommit(secondCommitSha), 2, BuildOptions.defaultOptions());
+    RepositoryBuildLauncher launcher = new RepositoryBuildLauncher(repositoryBuildService, branchService, moduleService, dependenciesService, moduleDiscoveryService, moduleDiscovery, gitHubHelper);
+
+    GHRepository repository = mock(GHRepository.class);
+
+    when(gitHubHelper.shaFor(any(), any())).thenReturn(Optional.of(secondCommitSha));
+    when(gitHubHelper.repositoryFor(any())).thenReturn(repository);
+
+    doAnswer(invocation -> {
+      String sha = (String) invocation.getArguments()[0];
+      return new GHCommit() {
+        @Override
+        public String getSHA1() {
+          return sha;
+        }
+      };
+    }).when(repository).getCommit(anyString());
+
+    doAnswer(invocation -> {
+      GHCommit commit = (GHCommit) invocation.getArguments()[0];
+      return Commit.newBuilder().setId(commit.getSHA1()).build();
+    }).when(gitHubHelper).toCommit(any());
+
+
+    // Test that the method was called with the expected arguments.
+    doAnswer(invocation -> {
+      Commit currentCommit = (Commit) invocation.getArguments()[1];
+      Optional<Commit> previousCommit = (Optional<Commit>) invocation.getArguments()[2];
+      assertThat(currentCommit.getId()).isEqualTo(secondCommitSha);
+      assertThat(previousCommit.isPresent()).isTrue();
+      assertThat(previousCommit.get().getId()).isEqualTo(initialCommitSha);
+      return null;
+    }).when(gitHubHelper).commitInfoFor(any(), any(), any());
+
+
+    launcher.commitInfo(branch, currentBuild, previousBuildOptional);
+  }
+}


### PR DESCRIPTION
If an InterProject build comes just after a push to a repository, but
before the push build is queued it can prevent Blazar from building
the changed modules correctly.

This change makes Blazar use the last built commit for InterProject
builds so that they behave like a "rebuild to pick up dependencies",
instead of having them pick up new commits and not build the right
modules.


