### PR TITLE
Prevent breakage on branches with no modules

### DIFF
--- a/BlazarData/src/main/java/com/hubspot/blazar/data/dao/StateDao.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/dao/StateDao.java
@@ -74,7 +74,7 @@ public interface StateDao {
       // pending build
       "     LEFT OUTER JOIN module_builds AS pendingModuleBuild ON (module.pendingBuildId = pendingModuleBuild.id) " +
       "     LEFT OUTER JOIN repo_builds AS pendingBranchBuild ON (pendingModuleBuild.repoBuildId = pendingBranchBuild.id) " +
-      "  WHERE branches.id = :branchId")
+      "  WHERE branches.id = :branchId AND module.id IS NOT NULL")
   Set<ModuleState> getLastAndInProgressAndPendingBuildsForBranchAndIncludedModules(@Bind("branchId") int branchId);
 
   /**

--- a/BlazarData/src/main/java/com/hubspot/blazar/data/dao/StateDao.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/dao/StateDao.java
@@ -64,7 +64,7 @@ public interface StateDao {
   @SqlQuery("" +
       "SELECT * " +
       "  FROM branches " +
-      "     LEFT OUTER JOIN modules as module on (branches.id = module.branchId) " +
+      "     JOIN modules as module on (branches.id = module.branchId) " +
       // last build
       "     LEFT OUTER JOIN module_builds AS lastModuleBuild ON (module.lastBuildId = lastModuleBuild.id) " +
       "     LEFT OUTER JOIN repo_builds AS lastBranchBuild ON (lastModuleBuild.repoBuildId = lastBranchBuild.id) " +
@@ -74,7 +74,7 @@ public interface StateDao {
       // pending build
       "     LEFT OUTER JOIN module_builds AS pendingModuleBuild ON (module.pendingBuildId = pendingModuleBuild.id) " +
       "     LEFT OUTER JOIN repo_builds AS pendingBranchBuild ON (pendingModuleBuild.repoBuildId = pendingBranchBuild.id) " +
-      "  WHERE branches.id = :branchId AND module.id IS NOT NULL")
+      "  WHERE branches.id = :branchId")
   Set<ModuleState> getLastAndInProgressAndPendingBuildsForBranchAndIncludedModules(@Bind("branchId") int branchId);
 
   /**


### PR DESCRIPTION
@andyhuang91 This fixes the 400 issue when fetching the state for a branch w/o any modules.