### PR TITLE
Fix issues with namespace clashing in our interal deployer

### DIFF
--- a/BlazarService/src/main/java/com/hubspot/blazar/BlazarService.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/BlazarService.java
@@ -4,7 +4,7 @@ import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.hubspot.blazar.command.CleanRepoMetadataCommand;
 import com.hubspot.blazar.command.VersionBackFillCommand;
-import com.hubspot.blazar.config.BlazarWrapperConfiguration;
+import com.hubspot.blazar.config.BlazarConfigurationWrapper;
 import com.hubspot.blazar.guice.BlazarServiceModule;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
 import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
@@ -18,15 +18,15 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
 
-public class BlazarService<T extends BlazarWrapperConfiguration> extends Application<T> {
+public class BlazarService<T extends BlazarConfigurationWrapper> extends Application<T> {
 
   @Override
   public void initialize(final Bootstrap<T> bootstrap) {
     bootstrap.addBundle(buildGuiceBundle());
-    bootstrap.addBundle(new MigrationsBundle<BlazarWrapperConfiguration>() {
+    bootstrap.addBundle(new MigrationsBundle<BlazarConfigurationWrapper>() {
 
       @Override
-      public DataSourceFactory getDataSourceFactory(final BlazarWrapperConfiguration configuration) {
+      public DataSourceFactory getDataSourceFactory(final BlazarConfigurationWrapper configuration) {
         return configuration.getBlazarConfiguration().getDatabaseConfiguration();
       }
     });
@@ -42,8 +42,8 @@ public class BlazarService<T extends BlazarWrapperConfiguration> extends Applica
   @Override
   public void run(final T configuration, final Environment environment) {}
 
-  private ConfiguredBundle<BlazarWrapperConfiguration> buildGuiceBundle() {
-    return GuiceBundle.defaultBuilder(BlazarWrapperConfiguration.class)
+  private ConfiguredBundle<BlazarConfigurationWrapper> buildGuiceBundle() {
+    return GuiceBundle.defaultBuilder(BlazarConfigurationWrapper.class)
         .enableGuiceEnforcer(false)
         .modules(new BlazarServiceModule()).build();
   }

--- a/BlazarService/src/main/java/com/hubspot/blazar/BlazarService.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/BlazarService.java
@@ -2,10 +2,10 @@ package com.hubspot.blazar;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.databind.DeserializationFeature;
-import com.hubspot.blazar.config.BlazarConfiguration;
-import com.hubspot.blazar.guice.BlazarServiceModule;
 import com.hubspot.blazar.command.CleanRepoMetadataCommand;
 import com.hubspot.blazar.command.VersionBackFillCommand;
+import com.hubspot.blazar.config.BlazarWrapperConfiguration;
+import com.hubspot.blazar.guice.BlazarServiceModule;
 import com.hubspot.dropwizard.guicier.GuiceBundle;
 import com.hubspot.jackson.datatype.protobuf.ProtobufModule;
 
@@ -18,16 +18,16 @@ import io.dropwizard.setup.Bootstrap;
 import io.dropwizard.setup.Environment;
 import io.dropwizard.views.ViewBundle;
 
-public class BlazarService<T extends BlazarConfiguration> extends Application<T> {
+public class BlazarService<T extends BlazarWrapperConfiguration> extends Application<T> {
 
   @Override
   public void initialize(final Bootstrap<T> bootstrap) {
     bootstrap.addBundle(buildGuiceBundle());
-    bootstrap.addBundle(new MigrationsBundle<BlazarConfiguration>() {
+    bootstrap.addBundle(new MigrationsBundle<BlazarWrapperConfiguration>() {
 
       @Override
-      public DataSourceFactory getDataSourceFactory(final BlazarConfiguration configuration) {
-        return configuration.getDatabaseConfiguration();
+      public DataSourceFactory getDataSourceFactory(final BlazarWrapperConfiguration configuration) {
+        return configuration.getBlazarConfiguration().getDatabaseConfiguration();
       }
     });
     bootstrap.addBundle(new AssetsBundle("/static"));
@@ -42,8 +42,8 @@ public class BlazarService<T extends BlazarConfiguration> extends Application<T>
   @Override
   public void run(final T configuration, final Environment environment) {}
 
-  private ConfiguredBundle<BlazarConfiguration> buildGuiceBundle() {
-    return GuiceBundle.defaultBuilder(BlazarConfiguration.class)
+  private ConfiguredBundle<BlazarWrapperConfiguration> buildGuiceBundle() {
+    return GuiceBundle.defaultBuilder(BlazarWrapperConfiguration.class)
         .enableGuiceEnforcer(false)
         .modules(new BlazarServiceModule()).build();
   }

--- a/BlazarService/src/main/java/com/hubspot/blazar/command/CleanRepoMetadataCommand.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/command/CleanRepoMetadataCommand.java
@@ -22,7 +22,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.hubspot.blazar.base.GitInfo;
-import com.hubspot.blazar.config.BlazarWrapperConfiguration;
+import com.hubspot.blazar.config.BlazarConfigurationWrapper;
 import com.hubspot.blazar.data.service.BranchService;
 import com.hubspot.blazar.guice.BaseCommandModule;
 import com.hubspot.blazar.util.GitHubHelper;
@@ -30,7 +30,7 @@ import com.hubspot.blazar.util.GitHubHelper;
 import io.dropwizard.cli.ConfiguredCommand;
 import io.dropwizard.setup.Bootstrap;
 
-public class CleanRepoMetadataCommand extends ConfiguredCommand<BlazarWrapperConfiguration> {
+public class CleanRepoMetadataCommand extends ConfiguredCommand<BlazarConfigurationWrapper> {
   private static final String COMMAND_NAME = "clean_repo_metadata";
   private static final String COMMAND_DESC = "Finds repos no longer in the managed organizations and marks all branches as inactive";
   private static final Logger LOG = LoggerFactory.getLogger(CleanRepoMetadataCommand.class);
@@ -56,9 +56,9 @@ public class CleanRepoMetadataCommand extends ConfiguredCommand<BlazarWrapperCon
 
   @Override
   protected void run(
-      Bootstrap<BlazarWrapperConfiguration> bootstrap,
+      Bootstrap<BlazarConfigurationWrapper> bootstrap,
       Namespace namespace,
-      BlazarWrapperConfiguration configuration) throws Exception {
+      BlazarConfigurationWrapper configuration) throws Exception {
 
     boolean noop = namespace.getBoolean(NOOP_FLAG);
     Injector injector = Guice.createInjector(new BaseCommandModule(bootstrap, configuration));

--- a/BlazarService/src/main/java/com/hubspot/blazar/command/CleanRepoMetadataCommand.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/command/CleanRepoMetadataCommand.java
@@ -22,7 +22,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 import com.google.inject.Guice;
 import com.google.inject.Injector;
 import com.hubspot.blazar.base.GitInfo;
-import com.hubspot.blazar.config.BlazarConfiguration;
+import com.hubspot.blazar.config.BlazarWrapperConfiguration;
 import com.hubspot.blazar.data.service.BranchService;
 import com.hubspot.blazar.guice.BaseCommandModule;
 import com.hubspot.blazar.util.GitHubHelper;
@@ -30,7 +30,7 @@ import com.hubspot.blazar.util.GitHubHelper;
 import io.dropwizard.cli.ConfiguredCommand;
 import io.dropwizard.setup.Bootstrap;
 
-public class CleanRepoMetadataCommand extends ConfiguredCommand<BlazarConfiguration> {
+public class CleanRepoMetadataCommand extends ConfiguredCommand<BlazarWrapperConfiguration> {
   private static final String COMMAND_NAME = "clean_repo_metadata";
   private static final String COMMAND_DESC = "Finds repos no longer in the managed organizations and marks all branches as inactive";
   private static final Logger LOG = LoggerFactory.getLogger(CleanRepoMetadataCommand.class);
@@ -56,9 +56,9 @@ public class CleanRepoMetadataCommand extends ConfiguredCommand<BlazarConfigurat
 
   @Override
   protected void run(
-      Bootstrap<BlazarConfiguration> bootstrap,
+      Bootstrap<BlazarWrapperConfiguration> bootstrap,
       Namespace namespace,
-      BlazarConfiguration configuration) throws Exception {
+      BlazarWrapperConfiguration configuration) throws Exception {
 
     boolean noop = namespace.getBoolean(NOOP_FLAG);
     Injector injector = Guice.createInjector(new BaseCommandModule(bootstrap, configuration));
@@ -73,7 +73,7 @@ public class CleanRepoMetadataCommand extends ConfiguredCommand<BlazarConfigurat
 
       while (!branchStack.isEmpty()) {
         GitInfo branch = branchStack.pop();
-        GitBranchUpdater updater = new GitBranchUpdater(branch, gitHubHelper, configuration, branchService, noop);
+        GitBranchUpdater updater = new GitBranchUpdater(branch, gitHubHelper, configuration.getBlazarConfiguration(), branchService, noop);
         try {
           futures.put(branch, CompletableFuture.runAsync(updater, executorService));
         } catch (RejectedExecutionException e) {

--- a/BlazarService/src/main/java/com/hubspot/blazar/command/VersionBackFillCommand.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/command/VersionBackFillCommand.java
@@ -21,7 +21,7 @@ import com.google.inject.Injector;
 import com.hubspot.blazar.base.DiscoveryResult;
 import com.hubspot.blazar.base.GitInfo;
 import com.hubspot.blazar.base.Module;
-import com.hubspot.blazar.config.BlazarConfiguration;
+import com.hubspot.blazar.config.BlazarWrapperConfiguration;
 import com.hubspot.blazar.data.service.DependenciesService;
 import com.hubspot.blazar.data.service.ModuleDiscoveryService;
 import com.hubspot.blazar.discovery.CompositeModuleDiscovery;
@@ -30,7 +30,7 @@ import com.hubspot.blazar.guice.BaseCommandModule;
 import io.dropwizard.cli.ConfiguredCommand;
 import io.dropwizard.setup.Bootstrap;
 
-public class VersionBackFillCommand extends ConfiguredCommand<BlazarConfiguration> {
+public class VersionBackFillCommand extends ConfiguredCommand<BlazarWrapperConfiguration> {
   private static String COMMAND_NAME = "version_backfill";
   private static String COMMAND_DESC = "Finds projects with no version data for their dependencies, and updates their versions";
   private static final Logger LOG = LoggerFactory.getLogger(VersionBackFillCommand.class);
@@ -43,9 +43,9 @@ public class VersionBackFillCommand extends ConfiguredCommand<BlazarConfiguratio
   }
 
   @Override
-  protected void run(Bootstrap<BlazarConfiguration> bootstrap,
+  protected void run(Bootstrap<BlazarWrapperConfiguration> bootstrap,
                      Namespace namespace,
-                     BlazarConfiguration configuration) throws Exception {
+                     BlazarWrapperConfiguration configuration) throws Exception {
     Injector injector = Guice.createInjector(new BaseCommandModule(bootstrap, configuration));
 
     try {

--- a/BlazarService/src/main/java/com/hubspot/blazar/command/VersionBackFillCommand.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/command/VersionBackFillCommand.java
@@ -21,7 +21,7 @@ import com.google.inject.Injector;
 import com.hubspot.blazar.base.DiscoveryResult;
 import com.hubspot.blazar.base.GitInfo;
 import com.hubspot.blazar.base.Module;
-import com.hubspot.blazar.config.BlazarWrapperConfiguration;
+import com.hubspot.blazar.config.BlazarConfigurationWrapper;
 import com.hubspot.blazar.data.service.DependenciesService;
 import com.hubspot.blazar.data.service.ModuleDiscoveryService;
 import com.hubspot.blazar.discovery.CompositeModuleDiscovery;
@@ -30,7 +30,7 @@ import com.hubspot.blazar.guice.BaseCommandModule;
 import io.dropwizard.cli.ConfiguredCommand;
 import io.dropwizard.setup.Bootstrap;
 
-public class VersionBackFillCommand extends ConfiguredCommand<BlazarWrapperConfiguration> {
+public class VersionBackFillCommand extends ConfiguredCommand<BlazarConfigurationWrapper> {
   private static String COMMAND_NAME = "version_backfill";
   private static String COMMAND_DESC = "Finds projects with no version data for their dependencies, and updates their versions";
   private static final Logger LOG = LoggerFactory.getLogger(VersionBackFillCommand.class);
@@ -43,9 +43,9 @@ public class VersionBackFillCommand extends ConfiguredCommand<BlazarWrapperConfi
   }
 
   @Override
-  protected void run(Bootstrap<BlazarWrapperConfiguration> bootstrap,
+  protected void run(Bootstrap<BlazarConfigurationWrapper> bootstrap,
                      Namespace namespace,
-                     BlazarWrapperConfiguration configuration) throws Exception {
+                     BlazarConfigurationWrapper configuration) throws Exception {
     Injector injector = Guice.createInjector(new BaseCommandModule(bootstrap, configuration));
 
     try {

--- a/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarConfiguration.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarConfiguration.java
@@ -19,42 +19,60 @@ import io.dropwizard.db.DataSourceFactory;
  */
 public class BlazarConfiguration {
 
+
+  // Defines the deployments of GitHub that Blazar can connect to.
   @NotNull
   @JsonProperty("github")
   private Map<String, GitHubConfiguration> gitHubConfiguration;
 
+  // The configuration required for Blazar to connect to Singularity
   @Valid
   @NotNull
   @JsonProperty("singularity")
   private SingularityConfiguration singularityConfiguration;
 
+  // Default options we pass to the executor
   @Valid
   @NotNull
   @JsonProperty("executor")
   private ExecutorConfiguration executorConfiguration = ExecutorConfiguration.defaultConfiguration();
 
+  // Configuration for Blazar to connect to Zookeeper
+  // Required for leader election, and for Blazar to enable the buildVisitors (only the master handles build events).
   @JsonProperty("zookeeper")
   private Optional<ZooKeeperConfiguration> zooKeeperConfiguration = Optional.absent();
 
+  /* The configuration for Blazar's mysql database
+   * database:
+   *   driverClass: com.mysql.jdbc.Driver
+   *   user: user
+   *   password: "password"
+   *   url: jdbc:mysql://host:3306/BlazarV2
+   */
   @Valid
   @NotNull
   @JsonProperty("database")
   private DataSourceFactory databaseConfiguration;
 
+  // Configuration for Blazar's Ui so the backend can correctly generate links to the UI.
   @Valid
   @NotNull
   @JsonProperty("ui")
   private UiConfiguration uiConfiguration;
 
+  // Optional Configuration for Slack.
+  // Blazar uses this configuration to send messages to channels and individuals about builds
   @Valid
   @JsonProperty("slack_blazar")
   private Optional<BlazarSlackConfiguration> slackConfiguration = Optional.absent();
 
   // allows you to opt-in whole repositories by name
   private Set<String> whitelist = Collections.emptySet();
+
   // allows you to opt out whole repositories by name
   private Set<String> blacklist = Collections.emptySet();
 
+  // Controls whether this instance of blazar is configured to only accept webhooks or not.
   private boolean webhookOnly = false;
 
   public Map<String, GitHubConfiguration> getGitHubConfiguration() {

--- a/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarConfiguration.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarConfiguration.java
@@ -11,11 +11,10 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 
-import io.dropwizard.Configuration;
 import io.dropwizard.db.DataSourceFactory;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class BlazarConfiguration extends Configuration {
+public class BlazarConfiguration {
 
   @NotNull
   @JsonProperty("github")

--- a/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarConfiguration.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarConfiguration.java
@@ -7,13 +7,16 @@ import java.util.Set;
 import javax.validation.Valid;
 import javax.validation.constraints.NotNull;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Optional;
 
 import io.dropwizard.db.DataSourceFactory;
 
-@JsonIgnoreProperties(ignoreUnknown = true)
+/**
+ * The configuration for Blazar.
+ * All options that control how the BlazarService behaves are configured here. These are wrapped by {@Link BlazarWrapperConfiguration}
+ * so that there is 1 top level key in the dropwizard yaml which contains all the Blazar properties.
+ */
 public class BlazarConfiguration {
 
   @NotNull

--- a/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarConfigurationWrapper.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarConfigurationWrapper.java
@@ -12,12 +12,12 @@ import io.dropwizard.Configuration;
  * options are available under a single key in the dropwizard yaml.
  */
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class BlazarWrapperConfiguration extends Configuration {
+public class BlazarConfigurationWrapper extends Configuration {
 
   private BlazarConfiguration blazarConfiguration;
 
   @JsonCreator
-  public BlazarWrapperConfiguration(@JsonProperty("blazarConfiguration") BlazarConfiguration blazarConfiguration) {
+  public BlazarConfigurationWrapper(@JsonProperty("blazarConfiguration") BlazarConfiguration blazarConfiguration) {
 
     this.blazarConfiguration = blazarConfiguration;
   }

--- a/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarSlackConfiguration.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarSlackConfiguration.java
@@ -22,6 +22,14 @@ public class BlazarSlackConfiguration {
   private Set<String> imWhitelist;
   private String username;
 
+  /**
+   * @param slackApiBaseUrl The slack api to point at
+   * @param slackApiToken Auth token for connecting
+   * @param username The username to post in slack as
+   * @param feedbackRoom The room to push feedback from our in-app feedback box to
+   * @param imWhitelist The list of users to directly slack when a build they pushed build fails
+   * @param imBlacklist The list of users not to slack when a build they pushed build fails
+   */
   @Inject
   public BlazarSlackConfiguration(@JsonProperty("slackApiBaseUrl") String slackApiBaseUrl,
                                   @JsonProperty("slackApiToken") String slackApiToken,

--- a/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarWrapperConfiguration.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarWrapperConfiguration.java
@@ -1,0 +1,24 @@
+package com.hubspot.blazar.config;
+
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import io.dropwizard.Configuration;
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class BlazarWrapperConfiguration extends Configuration {
+
+  private BlazarConfiguration blazarConfiguration;
+
+  @JsonCreator
+  public BlazarWrapperConfiguration(@JsonProperty("blazarConfiguration") BlazarConfiguration blazarConfiguration) {
+
+    this.blazarConfiguration = blazarConfiguration;
+  }
+
+  public BlazarConfiguration getBlazarConfiguration() {
+    return blazarConfiguration;
+  }
+}

--- a/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarWrapperConfiguration.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarWrapperConfiguration.java
@@ -7,6 +7,10 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import io.dropwizard.Configuration;
 
+/**
+ * This wraps {@Link BlazarConfiguration} so that all the Blazar configuration
+ * options are available under a single key in the dropwizard yaml.
+ */
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class BlazarWrapperConfiguration extends Configuration {
 

--- a/BlazarService/src/main/java/com/hubspot/blazar/config/ExecutorConfiguration.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/ExecutorConfiguration.java
@@ -1,13 +1,14 @@
 package com.hubspot.blazar.config;
 
+import java.util.concurrent.TimeUnit;
+
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Objects;
 import com.google.common.base.Optional;
-
-import javax.validation.constraints.Min;
-import javax.validation.constraints.NotNull;
-import java.util.concurrent.TimeUnit;
 
 public class ExecutorConfiguration {
 
@@ -17,6 +18,10 @@ public class ExecutorConfiguration {
   @Min(0)
   private final long buildTimeoutMillis;
 
+  /**
+   * @param defaultBuildUser The default user for builds to run as
+   * @param buildTimeoutMillis The time to wait before considering a running build to be stuck and for it to be killed.
+   */
   @JsonCreator
   public ExecutorConfiguration(@JsonProperty("defaultBuildUser") Optional<String> defaultBuildUser,
                                @JsonProperty("buildTimeoutMillis") Optional<Long> buildTimeoutMillis) {

--- a/BlazarService/src/main/java/com/hubspot/blazar/config/GitHubConfiguration.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/GitHubConfiguration.java
@@ -15,6 +15,13 @@ public class GitHubConfiguration {
   private final Optional<String> oauthToken;
   private final List<String> organizations;
 
+  /**
+   * @param user The username to use when interacting with GitHub.
+   * @param password The password to use.
+   * @param setCommitStatus We don't want to post build statuses to all GitHub instances we configure.
+   * @param oauthToken Alternate option to having a user/password you can use a user/token.
+   * @param organizations A list of all the organizations that Blazar will pay attention to pushes from.
+   */
   @JsonCreator
   public GitHubConfiguration(@JsonProperty("user") Optional<String> user,
                              @JsonProperty("password") Optional<String> password,

--- a/BlazarService/src/main/java/com/hubspot/blazar/guice/BaseCommandModule.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/guice/BaseCommandModule.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.MapBinder;
-import com.hubspot.blazar.config.BlazarConfiguration;
+import com.hubspot.blazar.config.BlazarWrapperConfiguration;
 import com.hubspot.blazar.config.GitHubConfiguration;
 import com.hubspot.blazar.data.BlazarDataModule;
 import com.hubspot.blazar.discovery.DiscoveryModule;
@@ -21,10 +21,10 @@ import io.dropwizard.setup.Bootstrap;
 
 public class BaseCommandModule extends AbstractModule {
 
-  private final Bootstrap<BlazarConfiguration> bootstrap;
-  private final BlazarConfiguration configuration;
+  private final Bootstrap<BlazarWrapperConfiguration> bootstrap;
+  private final BlazarWrapperConfiguration configuration;
 
-  public BaseCommandModule(Bootstrap<BlazarConfiguration> bootstrap, BlazarConfiguration configuration) {
+  public BaseCommandModule(Bootstrap<BlazarWrapperConfiguration> bootstrap, BlazarWrapperConfiguration configuration) {
     this.bootstrap = bootstrap;
     this.configuration = configuration;
   }
@@ -35,13 +35,13 @@ public class BaseCommandModule extends AbstractModule {
     bootstrap.getObjectMapper().configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
     bootstrap.getObjectMapper().registerModule(new ProtobufModule());
     binder().bind(ObjectMapper.class).toInstance(bootstrap.getObjectMapper());
-    binder().bind(DataSourceFactory.class).toInstance(configuration.getDatabaseConfiguration());
+    binder().bind(DataSourceFactory.class).toInstance(configuration.getBlazarConfiguration().getDatabaseConfiguration());
     binder().install(new BlazarDataModule());
     binder().install(new DiscoveryModule());
     binder().bind(GitHubHelper.class);
 
     MapBinder<String, GitHub> mapBinder = MapBinder.newMapBinder(binder(), String.class, GitHub.class);
-    for (Map.Entry<String, GitHubConfiguration> entry : configuration.getGitHubConfiguration().entrySet()) {
+    for (Map.Entry<String, GitHubConfiguration> entry : configuration.getBlazarConfiguration().getGitHubConfiguration().entrySet()) {
       String host = entry.getKey();
       mapBinder.addBinding(host).toInstance(BlazarServiceModule.toGitHub(host, entry.getValue()));
     }

--- a/BlazarService/src/main/java/com/hubspot/blazar/guice/BaseCommandModule.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/guice/BaseCommandModule.java
@@ -9,7 +9,7 @@ import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.inject.AbstractModule;
 import com.google.inject.multibindings.MapBinder;
-import com.hubspot.blazar.config.BlazarWrapperConfiguration;
+import com.hubspot.blazar.config.BlazarConfigurationWrapper;
 import com.hubspot.blazar.config.GitHubConfiguration;
 import com.hubspot.blazar.data.BlazarDataModule;
 import com.hubspot.blazar.discovery.DiscoveryModule;
@@ -21,10 +21,10 @@ import io.dropwizard.setup.Bootstrap;
 
 public class BaseCommandModule extends AbstractModule {
 
-  private final Bootstrap<BlazarWrapperConfiguration> bootstrap;
-  private final BlazarWrapperConfiguration configuration;
+  private final Bootstrap<BlazarConfigurationWrapper> bootstrap;
+  private final BlazarConfigurationWrapper configuration;
 
-  public BaseCommandModule(Bootstrap<BlazarWrapperConfiguration> bootstrap, BlazarWrapperConfiguration configuration) {
+  public BaseCommandModule(Bootstrap<BlazarConfigurationWrapper> bootstrap, BlazarConfigurationWrapper configuration) {
     this.bootstrap = bootstrap;
     this.configuration = configuration;
   }

--- a/BlazarService/src/main/java/com/hubspot/blazar/guice/BlazarServiceModule.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/guice/BlazarServiceModule.java
@@ -31,7 +31,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import com.hubspot.blazar.GitHubNamingFilter;
 import com.hubspot.blazar.config.BlazarConfiguration;
-import com.hubspot.blazar.config.BlazarWrapperConfiguration;
+import com.hubspot.blazar.config.BlazarConfigurationWrapper;
 import com.hubspot.blazar.config.GitHubConfiguration;
 import com.hubspot.blazar.config.SingularityConfiguration;
 import com.hubspot.blazar.data.BlazarDataModule;
@@ -66,7 +66,7 @@ import com.hubspot.singularity.client.SingularityClientModule;
 
 import io.dropwizard.db.DataSourceFactory;
 
-public class BlazarServiceModule extends DropwizardAwareModule<BlazarWrapperConfiguration> {
+public class BlazarServiceModule extends DropwizardAwareModule<BlazarConfigurationWrapper> {
   private static final Logger LOG = LoggerFactory.getLogger(BlazarServiceModule.class);
 
   @Override

--- a/BlazarService/src/main/java/com/hubspot/blazar/guice/BlazarServiceModule.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/guice/BlazarServiceModule.java
@@ -31,6 +31,7 @@ import com.google.inject.multibindings.Multibinder;
 import com.google.inject.name.Names;
 import com.hubspot.blazar.GitHubNamingFilter;
 import com.hubspot.blazar.config.BlazarConfiguration;
+import com.hubspot.blazar.config.BlazarWrapperConfiguration;
 import com.hubspot.blazar.config.GitHubConfiguration;
 import com.hubspot.blazar.config.SingularityConfiguration;
 import com.hubspot.blazar.data.BlazarDataModule;
@@ -65,26 +66,28 @@ import com.hubspot.singularity.client.SingularityClientModule;
 
 import io.dropwizard.db.DataSourceFactory;
 
-public class BlazarServiceModule extends DropwizardAwareModule<BlazarConfiguration> {
+public class BlazarServiceModule extends DropwizardAwareModule<BlazarWrapperConfiguration> {
   private static final Logger LOG = LoggerFactory.getLogger(BlazarServiceModule.class);
 
   @Override
   public void configure(Binder binder) {
+    BlazarConfiguration blazarConfiguration = getConfiguration().getBlazarConfiguration();
+
     binder.install(new BlazarEventBusModule());
-    binder.bind(DataSourceFactory.class).toInstance(getConfiguration().getDatabaseConfiguration());
+    binder.bind(DataSourceFactory.class).toInstance(blazarConfiguration.getDatabaseConfiguration());
     binder.bind(YAMLFactory.class).toInstance(new YAMLFactory());
     binder.bind(XmlFactory.class).toInstance(new XmlFactory());
     binder.bind(MetricRegistry.class).toInstance(getEnvironment().metrics());
     binder.bind(ObjectMapper.class).toInstance(getEnvironment().getObjectMapper());
     Multibinder.newSetBinder(binder, ContainerRequestFilter.class).addBinding().to(GitHubNamingFilter.class).in(Scopes.SINGLETON);
 
-    if (getConfiguration().isWebhookOnly()) {
+    if (blazarConfiguration.isWebhookOnly()) {
       return;
     }
 
     binder.install(new BlazarDataModule());
     binder.install(new DiscoveryModule());
-    binder.install(new BlazarSlackModule(getConfiguration()));
+    binder.install(new BlazarSlackModule(blazarConfiguration));
 
     binder.bind(IllegalArgumentExceptionMapper.class);
     binder.bind(IllegalStateExceptionMapper.class);
@@ -100,7 +103,7 @@ public class BlazarServiceModule extends DropwizardAwareModule<BlazarConfigurati
     binder.bind(InterProjectBuildResource.class);
 
     // Only configure leader-based activities like processing events etc. if you are connected to zookeeper
-    if (getConfiguration().getZooKeeperConfiguration().isPresent()) {
+    if (blazarConfiguration.getZooKeeperConfiguration().isPresent()) {
       binder.install(new BuildVisitorModule());
       binder.install(new BlazarQueueProcessorModule());
       binder.install(new BlazarZooKeeperModule());
@@ -127,7 +130,7 @@ public class BlazarServiceModule extends DropwizardAwareModule<BlazarConfigurati
     binder.bind(LoggingHandler.class);
 
     // Bind and configure Singularity client
-    SingularityConfiguration singularityConfiguration = getConfiguration().getSingularityConfiguration();
+    SingularityConfiguration singularityConfiguration = blazarConfiguration.getSingularityConfiguration();
     binder.install(new SingularityClientModule(ImmutableList.of(singularityConfiguration.getHost())));
     if (singularityConfiguration.getPath().isPresent()) {
       SingularityClientModule.bindContextPath(binder).toInstance(singularityConfiguration.getPath().get());
@@ -138,7 +141,7 @@ public class BlazarServiceModule extends DropwizardAwareModule<BlazarConfigurati
 
     // Bind GitHub configurations
     MapBinder<String, GitHub> mapBinder = MapBinder.newMapBinder(binder, String.class, GitHub.class);
-    for (Entry<String, GitHubConfiguration> entry : getConfiguration().getGitHubConfiguration().entrySet()) {
+    for (Entry<String, GitHubConfiguration> entry : blazarConfiguration.getGitHubConfiguration().entrySet()) {
       String host = entry.getKey();
       mapBinder.addBinding(host).toInstance(toGitHub(host, entry.getValue()));
     }
@@ -146,16 +149,22 @@ public class BlazarServiceModule extends DropwizardAwareModule<BlazarConfigurati
 
   @Provides
   @Singleton
+  public BlazarConfiguration getBlazarConfiguration() {
+    return getConfiguration().getBlazarConfiguration();
+  }
+
+  @Provides
+  @Singleton
   @Named("whitelist")
-  public Set<String> providesWhitelist(BlazarConfiguration configuration) {
-    return configuration.getWhitelist();
+  public Set<String> providesWhitelist() {
+    return getConfiguration().getBlazarConfiguration().getWhitelist();
   }
 
   @Provides
   @Singleton
   @Named("blacklist")
-  public Set<String> providesBlacklist(BlazarConfiguration configuration) {
-    return configuration.getBlacklist();
+  public Set<String> providesBlacklist() {
+    return getConfiguration().getBlazarConfiguration().getBlacklist();
   }
 
   @Provides

--- a/BlazarService/src/main/java/com/hubspot/blazar/guice/BlazarZooKeeperModule.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/guice/BlazarZooKeeperModule.java
@@ -13,7 +13,7 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
-import com.hubspot.blazar.config.BlazarConfiguration;
+import com.hubspot.blazar.config.BlazarWrapperConfiguration;
 import com.hubspot.blazar.queue.QueueProcessor;
 import com.hubspot.blazar.util.HostUtils;
 import com.hubspot.blazar.util.HostUtils.Host;
@@ -57,7 +57,7 @@ public class BlazarZooKeeperModule implements Module {
   @Provides
   @Singleton
   @Port
-  public int providesPort(BlazarConfiguration configuration) {
+  public int providesPort(BlazarWrapperConfiguration configuration) {
     SimpleServerFactory serverFactory = (SimpleServerFactory) configuration.getServerFactory();
     HttpConnectorFactory connector = (HttpConnectorFactory) serverFactory.getConnector();
     return connector.getPort();

--- a/BlazarService/src/main/java/com/hubspot/blazar/guice/BlazarZooKeeperModule.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/guice/BlazarZooKeeperModule.java
@@ -13,7 +13,7 @@ import com.google.inject.Provides;
 import com.google.inject.Scopes;
 import com.google.inject.Singleton;
 import com.google.inject.multibindings.Multibinder;
-import com.hubspot.blazar.config.BlazarWrapperConfiguration;
+import com.hubspot.blazar.config.BlazarConfigurationWrapper;
 import com.hubspot.blazar.queue.QueueProcessor;
 import com.hubspot.blazar.util.HostUtils;
 import com.hubspot.blazar.util.HostUtils.Host;
@@ -57,7 +57,7 @@ public class BlazarZooKeeperModule implements Module {
   @Provides
   @Singleton
   @Port
-  public int providesPort(BlazarWrapperConfiguration configuration) {
+  public int providesPort(BlazarConfigurationWrapper configuration) {
     SimpleServerFactory serverFactory = (SimpleServerFactory) configuration.getServerFactory();
     HttpConnectorFactory connector = (HttpConnectorFactory) serverFactory.getConnector();
     return connector.getPort();

--- a/BlazarService/src/main/java/com/hubspot/blazar/resources/UiResource.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/resources/UiResource.java
@@ -6,7 +6,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import com.google.inject.Inject;
-import com.hubspot.blazar.config.BlazarWrapperConfiguration;
+import com.hubspot.blazar.config.BlazarConfigurationWrapper;
 
 import io.dropwizard.server.SimpleServerFactory;
 import io.dropwizard.views.View;
@@ -17,7 +17,7 @@ public class UiResource {
     private final String basePath;
 
     @Inject
-    public UiResource(BlazarWrapperConfiguration configuration) {
+    public UiResource(BlazarConfigurationWrapper configuration) {
         this.basePath = ((SimpleServerFactory) configuration.getServerFactory()).getApplicationContextPath();
     }
 

--- a/BlazarService/src/main/java/com/hubspot/blazar/resources/UiResource.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/resources/UiResource.java
@@ -6,7 +6,7 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
 import com.google.inject.Inject;
-import com.hubspot.blazar.config.BlazarConfiguration;
+import com.hubspot.blazar.config.BlazarWrapperConfiguration;
 
 import io.dropwizard.server.SimpleServerFactory;
 import io.dropwizard.views.View;
@@ -17,7 +17,7 @@ public class UiResource {
     private final String basePath;
 
     @Inject
-    public UiResource(BlazarConfiguration configuration) {
+    public UiResource(BlazarWrapperConfiguration configuration) {
         this.basePath = ((SimpleServerFactory) configuration.getServerFactory()).getApplicationContextPath();
     }
 


### PR DESCRIPTION
@gchomatas 

Our internal fabric deploy was preventing us from deploying this because there was a config yaml namespace conflict on the key `github`. 

Rather than deal with more config clashes in the future I opted to re-name all the blazar specific options to `blazar####` so that when reading the config it is clear what properties are for the deployer and which are consumed by Blazar.