### PR TITLE
Fix a bug in failing malformed module builds

### DIFF
--- a/BlazarData/src/main/java/com/hubspot/blazar/data/service/ModuleBuildService.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/service/ModuleBuildService.java
@@ -213,9 +213,9 @@ public class ModuleBuildService {
     ModuleBuild queued =
         ModuleBuild.queuedBuild(repositoryBuild, module, nextBuildNumber, BuildConfig.makeDefaultBuildConfig(), BuildConfig.makeDefaultBuildConfig());
     long id = moduleBuildDao.enqueue(queued);
-    checkAffectedRowCount(moduleDao.updatePendingBuild(queued));
-
     ModuleBuild queuedWithId = queued.toBuilder().setId(Optional.of(id)).build();
+    checkAffectedRowCount(moduleDao.updatePendingBuild(queuedWithId));
+
     LOG.info("Enqueued build for module {} with id {}", module.getId().get(), id);
     ModuleBuild failed = fail(queuedWithId);
     LOG.info("Failed build for module {} with id {}", module.getId().get(), id);


### PR DESCRIPTION
@gchomatas Fixes a bug in https://github.com/HubSpot/Blazar/pull/343. The updatePendingBuild needs to be passed a build with the buildId field populated.