### PR TITLE
Mysql considered 🎩 and 💥  to be the same

### DIFF
--- a/BlazarData/src/main/resources/schema.sql
+++ b/BlazarData/src/main/resources/schema.sql
@@ -214,3 +214,6 @@ CREATE TABLE queue_items (
 
 CREATE INDEX build_state_and_timestamps on repo_builds (state, endTimestamp, startTimestamp);
 DROP INDEX build_state on repo_builds;
+
+-- changeset jgoodwin:15
+ALTER TABLE `branches` MODIFY `branch` varchar(190) CHARACTER SET utf8mb4 COLLATE utf8mb4_bin;

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackDmNotificationVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackDmNotificationVisitor.java
@@ -59,7 +59,7 @@ public class SlackDmNotificationVisitor implements RepositoryBuildVisitor {
   }
 
   private Set<String> getUserEmailsToDirectlyNotify(RepositoryBuild build) {
-    if (build.getCommitInfo().isPresent()) {
+    if (!build.getCommitInfo().isPresent()) {
       LOG.info("No commit info present cannot determine user to slack");
       return Collections.emptySet();
     }


### PR DESCRIPTION
Updating collation to `utf8mb4_bin` fixed the issue.

Mysql's `utf8mb4_unicode_ci` and `utf8mb4_unicode_520_ci` collations can't differentiate emoji correctly. The only way to guarantee mysql correctly identifying uniqueness is to use the binary collation. 

CC: @gchomatas 