### PR TITLE
Allow us to silence direct-messages for certain branches

### DIFF
--- a/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarSlackConfiguration.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarSlackConfiguration.java
@@ -14,27 +14,27 @@ public class BlazarSlackConfiguration {
   private final String slackApiBaseUrl;
   private final String slackApiToken;
   private final Optional<String> feedbackRoom;
-  private BlazarSlackDirectMessageConfiguration blazarSlackDirectMessageConfiguration;
+  private BlazarSlackDirectMessageConfiguration directMessageConfiguration;
   private String username;
 
   /**
-   * @param slackApiBaseUrl The slack api to point at
-   * @param slackApiToken Auth token for connecting
-   * @param username The username to post in slack as
-   * @param feedbackRoom The room to push feedback from our in-app feedback box to
-   * @param blazarSlackDirectMessageConfiguration The configuration for blazar's direct-message functionality
+   * @param slackApiBaseUrl            The slack api to point at
+   * @param slackApiToken              Auth token for connecting
+   * @param username                   The username to post in slack as
+   * @param feedbackRoom               The room to push feedback from our in-app feedback box to
+   * @param directMessageConfiguration The configuration for blazar's direct-message functionality
    */
   @Inject
   public BlazarSlackConfiguration(@JsonProperty("slackApiBaseUrl") String slackApiBaseUrl,
                                   @JsonProperty("slackApiToken") String slackApiToken,
                                   @JsonProperty("username") String username,
                                   @JsonProperty("feedbackRoom") Optional<String> feedbackRoom,
-                                  @JsonProperty("directMessageConfiguration") BlazarSlackDirectMessageConfiguration blazarSlackDirectMessageConfiguration) {
+                                  @JsonProperty("directMessageConfiguration") BlazarSlackDirectMessageConfiguration directMessageConfiguration) {
     this.slackApiBaseUrl = slackApiBaseUrl;
     this.slackApiToken = slackApiToken;
     this.username = username;
     this.feedbackRoom = feedbackRoom;
-    this.blazarSlackDirectMessageConfiguration = blazarSlackDirectMessageConfiguration;
+    this.directMessageConfiguration = directMessageConfiguration;
   }
 
   public String getSlackApiBaseUrl() {
@@ -53,7 +53,8 @@ public class BlazarSlackConfiguration {
     return feedbackRoom;
   }
 
-  public BlazarSlackDirectMessageConfiguration getBlazarSlackDirectMessageConfiguration() {
-    return blazarSlackDirectMessageConfiguration;
+  public BlazarSlackDirectMessageConfiguration getDirectMessageConfiguration() {
+    return directMessageConfiguration;
   }
 }
+

--- a/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarSlackConfiguration.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarSlackConfiguration.java
@@ -1,12 +1,8 @@
 package com.hubspot.blazar.config;
 
-import java.util.Collections;
-import java.util.Set;
-
 import org.hibernate.validator.constraints.NotEmpty;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.inject.Inject;
 import com.sun.istack.internal.NotNull;
@@ -18,8 +14,7 @@ public class BlazarSlackConfiguration {
   private final String slackApiBaseUrl;
   private final String slackApiToken;
   private final Optional<String> feedbackRoom;
-  private final Set<String> imBlacklist;
-  private Set<String> imWhitelist;
+  private BlazarSlackDirectMessageConfiguration blazarSlackDirectMessageConfiguration;
   private String username;
 
   /**
@@ -27,22 +22,19 @@ public class BlazarSlackConfiguration {
    * @param slackApiToken Auth token for connecting
    * @param username The username to post in slack as
    * @param feedbackRoom The room to push feedback from our in-app feedback box to
-   * @param imWhitelist The list of users to directly slack when a build they pushed build fails
-   * @param imBlacklist The list of users not to slack when a build they pushed build fails
+   * @param blazarSlackDirectMessageConfiguration The configuration for blazar's direct-message functionality
    */
   @Inject
   public BlazarSlackConfiguration(@JsonProperty("slackApiBaseUrl") String slackApiBaseUrl,
                                   @JsonProperty("slackApiToken") String slackApiToken,
                                   @JsonProperty("username") String username,
                                   @JsonProperty("feedbackRoom") Optional<String> feedbackRoom,
-                                  @JsonProperty("imWhitelist") Set<String> imWhitelist,
-                                  @JsonProperty("imBlacklist") Set<String> imBlacklist) {
+                                  @JsonProperty("directMessageConfiguration") BlazarSlackDirectMessageConfiguration blazarSlackDirectMessageConfiguration) {
     this.slackApiBaseUrl = slackApiBaseUrl;
     this.slackApiToken = slackApiToken;
     this.username = username;
     this.feedbackRoom = feedbackRoom;
-    this.imWhitelist = MoreObjects.firstNonNull(imWhitelist, Collections.emptySet());
-    this.imBlacklist = MoreObjects.firstNonNull(imBlacklist, Collections.emptySet());
+    this.blazarSlackDirectMessageConfiguration = blazarSlackDirectMessageConfiguration;
   }
 
   public String getSlackApiBaseUrl() {
@@ -61,11 +53,7 @@ public class BlazarSlackConfiguration {
     return feedbackRoom;
   }
 
-  public Set<String> getImWhitelist() {
-    return imWhitelist;
-  }
-
-  public Set<String> getImBlacklist() {
-    return imBlacklist;
+  public BlazarSlackDirectMessageConfiguration getBlazarSlackDirectMessageConfiguration() {
+    return blazarSlackDirectMessageConfiguration;
   }
 }

--- a/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarSlackDirectMessageConfiguration.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/BlazarSlackDirectMessageConfiguration.java
@@ -1,0 +1,42 @@
+package com.hubspot.blazar.config;
+
+import java.util.Collections;
+import java.util.Set;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
+
+public class BlazarSlackDirectMessageConfiguration {
+
+  private final Set<String> whitelistedUserEmails;
+  private final Set<String> blacklistedUserEmails;
+  private final Set<String> ignoredBranches;
+
+  /**
+   * @param whitelistedUserEmails The list of users to directly slack when a build they pushed build fails
+   * @param blacklistedUserEmails list of users not to slack when a build they pushed build fails
+   * @param ignoredBranches The list of branches not to send direct message build alerts for. Useful to silence notifications for mass pull-requests.
+   */
+  @JsonCreator
+  public BlazarSlackDirectMessageConfiguration(@JsonProperty("whitelistedUserEmails") Set<String> whitelistedUserEmails,
+                                               @JsonProperty("blacklistedUserEmails") Set<String> blacklistedUserEmails,
+                                               @JsonProperty("ignoredBranches") Set<String> ignoredBranches) {
+
+    this.whitelistedUserEmails = MoreObjects.firstNonNull(whitelistedUserEmails, Collections.emptySet());
+    this.blacklistedUserEmails = MoreObjects.firstNonNull(blacklistedUserEmails, Collections.emptySet());
+    this.ignoredBranches = MoreObjects.firstNonNull(ignoredBranches, Collections.emptySet());
+  }
+
+  public Set<String> getWhitelistedUserEmails() {
+    return whitelistedUserEmails;
+  }
+
+  public Set<String> getBlacklistedUserEmails() {
+    return blacklistedUserEmails;
+  }
+
+  public Set<String> getIgnoredBranches() {
+    return ignoredBranches;
+  }
+}

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackDmNotificationVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackDmNotificationVisitor.java
@@ -43,7 +43,7 @@ public class SlackDmNotificationVisitor implements RepositoryBuildVisitor {
     this.branchService = branchService;
     this.slackMessageBuildingUtils = slackMessageBuildingUtils;
     this.blazarSlackClient = blazarSlackClient;
-    this.slackConfig = blazarConfiguration.getSlackConfiguration().get().getBlazarSlackDirectMessageConfiguration();
+    this.slackConfig = blazarConfiguration.getSlackConfiguration().get().getDirectMessageConfiguration();
   }
 
   @Override

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackDmNotificationVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackDmNotificationVisitor.java
@@ -29,7 +29,7 @@ public class SlackDmNotificationVisitor implements RepositoryBuildVisitor {
   // Cancelled requires a user action - likely the user who would be slacked anyway so it is not worth messaging about
   private static final Set<RepositoryBuild.State> SLACK_WORTHY_FAILING_STATES = ImmutableSet.of(FAILED, UNSTABLE);
   private static final Logger LOG = LoggerFactory.getLogger(SlackDmNotificationVisitor.class);
-  private final BlazarSlackDirectMessageConfiguration slackConfig;
+  private final BlazarSlackDirectMessageConfiguration slackDirectMessageConfig;
 
   private final BranchService branchService;
   private final SlackMessageBuildingUtils slackMessageBuildingUtils;
@@ -43,7 +43,7 @@ public class SlackDmNotificationVisitor implements RepositoryBuildVisitor {
     this.branchService = branchService;
     this.slackMessageBuildingUtils = slackMessageBuildingUtils;
     this.blazarSlackClient = blazarSlackClient;
-    this.slackConfig = blazarConfiguration.getSlackConfiguration().get().getDirectMessageConfiguration();
+    this.slackDirectMessageConfig = blazarConfiguration.getSlackConfiguration().get().getDirectMessageConfiguration();
   }
 
   @Override
@@ -72,14 +72,14 @@ public class SlackDmNotificationVisitor implements RepositoryBuildVisitor {
         build.getCommitInfo().get().getCurrent().getAuthor().getEmail(), // Author Email
         build.getCommitInfo().get().getCurrent().getAuthor().getEmail()); // Committer Email
 
-    directNotifyEmails.removeAll(slackConfig.getBlacklistedUserEmails());
+    directNotifyEmails.removeAll(slackDirectMessageConfig.getBlacklistedUserEmails());
 
     // If the white list is empty we send to author/committer
     // else we only send to the whitelisted members
-    if (slackConfig.getWhitelistedUserEmails().isEmpty()) {
+    if (slackDirectMessageConfig.getWhitelistedUserEmails().isEmpty()) {
       return directNotifyEmails;
     } else {
-      return Sets.intersection(directNotifyEmails, slackConfig.getWhitelistedUserEmails());
+      return Sets.intersection(directNotifyEmails, slackDirectMessageConfig.getWhitelistedUserEmails());
     }
   }
 
@@ -90,8 +90,8 @@ public class SlackDmNotificationVisitor implements RepositoryBuildVisitor {
 
     // Do not send notifications for builds of branches that are explicitly ignored
     String branchName = branchService.get(build.getBranchId()).get().getBranch();
-    if (slackConfig.getIgnoredBranches().contains(branchName)) {
-      LOG.info("Not sending messages for build {} because the branch is in the list of ignored branches {}", build, slackConfig.getIgnoredBranches());
+    if (slackDirectMessageConfig.getIgnoredBranches().contains(branchName)) {
+      LOG.info("Not sending messages for build {} because the branch is in the list of ignored branches {}", build, slackDirectMessageConfig.getIgnoredBranches());
       return false;
     }
 

--- a/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackDmNotificationVisitor.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/listener/SlackDmNotificationVisitor.java
@@ -17,7 +17,8 @@ import com.hubspot.blazar.base.BuildTrigger;
 import com.hubspot.blazar.base.RepositoryBuild;
 import com.hubspot.blazar.base.visitor.RepositoryBuildVisitor;
 import com.hubspot.blazar.config.BlazarConfiguration;
-import com.hubspot.blazar.config.BlazarSlackConfiguration;
+import com.hubspot.blazar.config.BlazarSlackDirectMessageConfiguration;
+import com.hubspot.blazar.data.service.BranchService;
 import com.hubspot.blazar.util.BlazarSlackClient;
 import com.hubspot.blazar.util.SlackMessageBuildingUtils;
 
@@ -28,18 +29,21 @@ public class SlackDmNotificationVisitor implements RepositoryBuildVisitor {
   // Cancelled requires a user action - likely the user who would be slacked anyway so it is not worth messaging about
   private static final Set<RepositoryBuild.State> SLACK_WORTHY_FAILING_STATES = ImmutableSet.of(FAILED, UNSTABLE);
   private static final Logger LOG = LoggerFactory.getLogger(SlackDmNotificationVisitor.class);
-  private final BlazarSlackConfiguration blazarSlackConfig;
+  private final BlazarSlackDirectMessageConfiguration slackConfig;
 
+  private final BranchService branchService;
   private final SlackMessageBuildingUtils slackMessageBuildingUtils;
   private final BlazarSlackClient blazarSlackClient;
 
   @Inject
   public SlackDmNotificationVisitor(BlazarConfiguration blazarConfiguration,
+                                    BranchService branchService,
                                     SlackMessageBuildingUtils slackMessageBuildingUtils,
                                     BlazarSlackClient blazarSlackClient) {
+    this.branchService = branchService;
     this.slackMessageBuildingUtils = slackMessageBuildingUtils;
     this.blazarSlackClient = blazarSlackClient;
-    this.blazarSlackConfig = blazarConfiguration.getSlackConfiguration().get();
+    this.slackConfig = blazarConfiguration.getSlackConfiguration().get().getBlazarSlackDirectMessageConfiguration();
   }
 
   @Override
@@ -68,19 +72,26 @@ public class SlackDmNotificationVisitor implements RepositoryBuildVisitor {
         build.getCommitInfo().get().getCurrent().getAuthor().getEmail(), // Author Email
         build.getCommitInfo().get().getCurrent().getAuthor().getEmail()); // Committer Email
 
-    directNotifyEmails.removeAll(blazarSlackConfig.getImBlacklist());
+    directNotifyEmails.removeAll(slackConfig.getBlacklistedUserEmails());
 
     // If the white list is empty we send to author/committer
     // else we only send to the whitelisted members
-    if (blazarSlackConfig.getImWhitelist().isEmpty()) {
+    if (slackConfig.getWhitelistedUserEmails().isEmpty()) {
       return directNotifyEmails;
     } else {
-      return Sets.intersection(directNotifyEmails, blazarSlackConfig.getImWhitelist());
+      return Sets.intersection(directNotifyEmails, slackConfig.getWhitelistedUserEmails());
     }
   }
 
   private boolean shouldSendMessage(RepositoryBuild build, Set<String> userEmailsToSendMessagesTo) {
     if (userEmailsToSendMessagesTo.isEmpty()) {
+      return false;
+    }
+
+    // Do not send notifications for builds of branches that are explicitly ignored
+    String branchName = branchService.get(build.getBranchId()).get().getBranch();
+    if (slackConfig.getIgnoredBranches().contains(branchName)) {
+      LOG.info("Not sending messages for build {} because the branch is in the list of ignored branches {}", build, slackConfig.getIgnoredBranches());
       return false;
     }
 


### PR DESCRIPTION
I refactored the Direct message configuration into its own class so that its clear what parts of the configuration are for Blazar's slack config in general vs the direct-message part.

@gchomatas 
