### PR TITLE
better logging for broken upserts

### DIFF
--- a/BlazarData/src/main/java/com/hubspot/blazar/data/service/BranchService.java
+++ b/BlazarData/src/main/java/com/hubspot/blazar/data/service/BranchService.java
@@ -72,7 +72,11 @@ public class BranchService {
         return gitInfo.withId(id);
       } catch (UnableToExecuteStatementException e) {
         if (e.getCause() instanceof SQLIntegrityConstraintViolationException) {
-          return getByRepositoryAndBranch(gitInfo.getRepositoryId(), gitInfo.getBranch()).get();
+          Optional<GitInfo> maybeBranch = getByRepositoryAndBranch(gitInfo.getRepositoryId(), gitInfo.getBranch());
+          if (!maybeBranch.isPresent()) {
+            throw new RuntimeException(String.format("Unable to upsert gitInfo %s", gitInfo));
+          }
+          return maybeBranch.get();
         } else {
           throw e;
         }


### PR DESCRIPTION
We were seeing a sentry on the removed line for a failing `Optional.get()` this will give us a bit more context around what is happening there.