### PR TITLE
Fix uses of Guava Objects / More Objects

### DIFF
--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildCommand.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildCommand.java
@@ -8,7 +8,7 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
@@ -40,8 +40,8 @@ public class BuildCommand {
       this.args = Arrays.asList(DEFAULT_ARG, command.get());
     }
 
-    this.successfulReturnCodes = Objects.firstNonNull(successfulReturnCodes, DEFAULT_SUCCESSFUL_RETURN_CODES);
-    this.env = Objects.firstNonNull(env, Collections.<String, String>emptyMap());
+    this.successfulReturnCodes = MoreObjects.firstNonNull(successfulReturnCodes, DEFAULT_SUCCESSFUL_RETURN_CODES);
+    this.env = MoreObjects.firstNonNull(env, Collections.<String, String>emptyMap());
   }
 
   public BuildCommand(String executable, List<String> args) {

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildOptions.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildOptions.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableSet;
 
@@ -25,7 +26,7 @@ public class BuildOptions {
   public BuildOptions(@JsonProperty("moduleIds") Set<Integer> moduleIds,
                       @JsonProperty("buildDownstreams") BuildDownstreams buildDownstreams,
                       @JsonProperty("resetCaches") boolean resetCaches) {
-    this.moduleIds = com.google.common.base.Objects.firstNonNull(moduleIds, ImmutableSet.<Integer>of());
+    this.moduleIds = MoreObjects.firstNonNull(moduleIds, ImmutableSet.<Integer>of());
     this.buildDownstreams = Preconditions.checkNotNull(buildDownstreams);
     this.resetCaches = resetCaches;
   }

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildStep.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/BuildStep.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 
 public class BuildStep {
@@ -19,10 +19,10 @@ public class BuildStep {
                    @JsonProperty("description") Optional<String> description,
                    @JsonProperty("commands") List<BuildCommand> commands,
                    @JsonProperty("activeByDefault") Optional<Boolean> activeByDefault) {
-    this.name = Objects.firstNonNull(name, Optional.<String>absent());
-    this.description = Objects.firstNonNull(description, Optional.<String>absent());
-    this.commands = Objects.firstNonNull(commands, Collections.<BuildCommand>emptyList());
-    this.activeByDefault = Objects.firstNonNull(activeByDefault, Optional.<Boolean>absent()).or(true);
+    this.name = MoreObjects.firstNonNull(name, Optional.<String>absent());
+    this.description = MoreObjects.firstNonNull(description, Optional.<String>absent());
+    this.commands = MoreObjects.firstNonNull(commands, Collections.<BuildCommand>emptyList());
+    this.activeByDefault = MoreObjects.firstNonNull(activeByDefault, Optional.<Boolean>absent()).or(true);
   }
 
   public Optional<String> getName() {

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/DependencyGraph.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/DependencyGraph.java
@@ -11,7 +11,7 @@ import java.util.Stack;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
 
@@ -89,7 +89,7 @@ public class DependencyGraph {
   }
 
   public Set<Integer> outgoingVertices(int moduleId) {
-    return Objects.firstNonNull(transitiveReduction.get(moduleId), Collections.<Integer>emptySet());
+    return MoreObjects.firstNonNull(transitiveReduction.get(moduleId), Collections.<Integer>emptySet());
   }
 
   @Override

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/InterProjectBuild.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/InterProjectBuild.java
@@ -5,6 +5,7 @@ import java.util.Set;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 import com.hubspot.rosetta.annotations.StoredAsJson;
 
@@ -106,7 +107,7 @@ public class InterProjectBuild {
 
   @Override
   public String toString() {
-    return com.google.common.base.Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("id", id)
         .add("state", state)
         .toString();

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/InterProjectBuildMapping.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/InterProjectBuildMapping.java
@@ -4,6 +4,7 @@ import java.util.Objects;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 
 public class InterProjectBuildMapping {
@@ -75,7 +76,7 @@ public class InterProjectBuildMapping {
 
   @Override
   public String toString() {
-    return com.google.common.base.Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("id", id)
         .add("interProjectBuildId", interProjectBuildId)
         .add("branchId", branchId)

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/Module.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/Module.java
@@ -45,7 +45,7 @@ public class Module {
     this.active = active;
     this.createdTimestamp = createdTimestamp;
     this.updatedTimestamp = updatedTimestamp;
-    this.buildpack = com.google.common.base.Objects.firstNonNull(buildpack, Optional.<GitInfo>absent());
+    this.buildpack = MoreObjects.firstNonNull(buildpack, Optional.<GitInfo>absent());
   }
 
   public Optional<Integer> getId() {

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/PostBuildSteps.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/PostBuildSteps.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 
 /**
  * Steps executed after a build, field of {@link BuildConfig}
@@ -19,9 +19,9 @@ public class PostBuildSteps {
   public PostBuildSteps(@JsonProperty("onFailure") List<BuildStep> onFailure,
                         @JsonProperty("onSuccess") List<BuildStep> onSuccess,
                         @JsonProperty("always") List<BuildStep> always) {
-    this.onFailure = Objects.firstNonNull(onFailure, Collections.emptyList());
-    this.onSuccess = Objects.firstNonNull(onSuccess, Collections.emptyList());
-    this.always = Objects.firstNonNull(always, Collections.emptyList());
+    this.onFailure = MoreObjects.firstNonNull(onFailure, Collections.emptyList());
+    this.onSuccess = MoreObjects.firstNonNull(onSuccess, Collections.emptyList());
+    this.always = MoreObjects.firstNonNull(always, Collections.emptyList());
   }
 
   public List<BuildStep> getOnFailure() {

--- a/BlazarBase/src/main/java/com/hubspot/blazar/base/RepositoryBuild.java
+++ b/BlazarBase/src/main/java/com/hubspot/blazar/base/RepositoryBuild.java
@@ -134,7 +134,7 @@ public class RepositoryBuild {
 
   @Override
   public String toString() {
-    return com.google.common.base.Objects.toStringHelper(this)
+    return MoreObjects.toStringHelper(this)
         .add("id", id)
         .add("branchId", branchId)
         .add("buildNumber", buildNumber)

--- a/BlazarService/src/main/java/com/hubspot/blazar/config/GitHubConfiguration.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/GitHubConfiguration.java
@@ -5,7 +5,7 @@ import java.util.List;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Objects;
+import com.google.common.base.MoreObjects;
 import com.google.common.base.Optional;
 
 public class GitHubConfiguration {
@@ -32,7 +32,7 @@ public class GitHubConfiguration {
     this.password = password;
     this.setCommitStatus = setCommitStatus.or(true);
     this.oauthToken = oauthToken;
-    this.organizations = Objects.firstNonNull(organizations, Collections.<String>emptyList());
+    this.organizations = MoreObjects.firstNonNull(organizations, Collections.<String>emptyList());
   }
 
   public Optional<String> getUser() {


### PR DESCRIPTION
This migrates the use of [deprecated `com.google.common.base.Objects` methods](https://google.github.io/guava/releases/19.0/api/docs/com/google/common/base/Objects.html).

@jonathanwgoodwin @gchomatas 