### PR TITLE
Add timeout for launching containers

### DIFF
--- a/BlazarService/src/main/java/com/hubspot/blazar/config/ExecutorConfiguration.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/config/ExecutorConfiguration.java
@@ -18,6 +18,9 @@ public class ExecutorConfiguration {
 
   @Min(0)
   private final long buildTimeoutMillis;
+
+  @Min(0)
+  private final long containerStartTimeoutMillis;
   // This is left as optional because the request that you configure in
   // is the last set of default options
   private final Optional<BuildCGroupResources> defaultBuildResources;
@@ -25,19 +28,22 @@ public class ExecutorConfiguration {
   /**
    * @param defaultBuildUser The default user for builds to run as
    * @param buildTimeoutMillis The time to wait before considering a running build to be stuck and for it to be killed.
+   * @param containerStartTimeoutMillis The time to wait before considering the container launch to have failed. Hitting this limit fails the module build.
    */
   @JsonCreator
   public ExecutorConfiguration(@JsonProperty("defaultBuildUser") Optional<String> defaultBuildUser,
                                @JsonProperty("defaultBuildResources") Optional<BuildCGroupResources> defaultBuildResources,
-                               @JsonProperty("buildTimeoutMillis") Optional<Long> buildTimeoutMillis) {
+                               @JsonProperty("buildTimeoutMillis") Optional<Long> buildTimeoutMillis,
+                               @JsonProperty("containerStartTimeoutMillis") Optional<Long> containerStartTimeoutMillis) {
 
     this.defaultBuildResources = MoreObjects.firstNonNull(defaultBuildResources, Optional.<BuildCGroupResources>absent());
     this.defaultBuildUser = MoreObjects.firstNonNull(defaultBuildUser, Optional.<String>absent()).or("root");
     this.buildTimeoutMillis = MoreObjects.firstNonNull(buildTimeoutMillis, Optional.<Long>absent()).or(TimeUnit.MINUTES.toMillis(20));
+    this.containerStartTimeoutMillis = MoreObjects.firstNonNull(containerStartTimeoutMillis, Optional.<Long>absent()).or(TimeUnit.MINUTES.toMillis(5));
   }
 
   public static ExecutorConfiguration defaultConfiguration() {
-    return new ExecutorConfiguration(Optional.absent(), Optional.absent(), Optional.absent());
+    return new ExecutorConfiguration(Optional.absent(), Optional.absent(), Optional.absent(), Optional.absent());
   }
 
   public String getDefaultBuildUser() {
@@ -50,5 +56,9 @@ public class ExecutorConfiguration {
 
   public Optional<BuildCGroupResources> getDefaultBuildResources() {
     return defaultBuildResources;
+  }
+
+  public long getContainerStartTimeoutMillis() {
+    return containerStartTimeoutMillis;
   }
 }

--- a/BlazarService/src/main/java/com/hubspot/blazar/externalservice/LostBuildCleaner.java
+++ b/BlazarService/src/main/java/com/hubspot/blazar/externalservice/LostBuildCleaner.java
@@ -33,7 +33,7 @@ import io.dropwizard.lifecycle.Managed;
  * This can happen when a build container is killed by mesos because of an OOM, or is lost
  * due to slave disconnections etc. When we find out that a build container has finished
  * running without reporting SUCCESS back to Blazar we consider that build failed.
- *
+ * <p>
  * We also watch for builds that have been running for longer than the maximum time configured.
  * If we find a build container that has been running for longer than the configured time we kill
  * the container and fail the build.
@@ -114,7 +114,29 @@ public class LostBuildCleaner implements LeaderLatchListener, Managed {
 
         BuildContainerInfo buildContainerInfo = buildClusterService.getBuildContainerInfo(moduleBuild);
         BuildContainerState buildContainerState = buildContainerInfo.getState();
-        //If the container has not yet started, it is running, or we don't know its state we will wait to check again in the next cycle
+
+        if (buildContainerState == NOT_STARTED && age > executorConfiguration.getContainerStartTimeoutMillis()) {
+          LOG.info("Updating module build {} of module {} to FAILED because the container has not started in cluster {} before the timeout ({}ms)",
+              moduleBuild.getBuildNumber(),
+              moduleBuild.getModuleId(),
+              moduleBuild.getBuildClusterName(),
+              executorConfiguration.getContainerStartTimeoutMillis());
+          moduleBuildService.update(moduleBuild.toBuilder()
+              .setState(State.FAILED)
+              .setTaskId(buildContainerInfo.getContainerId())
+              .setEndTimestamp(Optional.of(buildContainerInfo.getUpdatedAtMillis()))
+              .build());
+          return;
+        } else if (buildContainerState == UNKNOWN && age > executorConfiguration.getContainerStartTimeoutMillis()) {
+          LOG.error("The container for build {} is in an unknown state and has not started in {}ms " +
+              "this could mean that Blazar is leaking build containers into cluster {}",
+              moduleBuild,
+              executorConfiguration.getContainerStartTimeoutMillis(),
+              moduleBuild.getBuildClusterName());
+          return;
+        }
+
+        //If the container isn't over its time limit and has not yet started, or it is running, or we don't know its state we will wait to check again in the next cycle
         if (buildContainerState == NOT_STARTED || buildContainerState == RUNNING || buildContainerState == UNKNOWN) {
           return;
         }

--- a/BlazarService/src/test/java/com/hubspot/blazar/util/BlazarConfigUtilsTest.java
+++ b/BlazarService/src/test/java/com/hubspot/blazar/util/BlazarConfigUtilsTest.java
@@ -30,12 +30,13 @@ public class BlazarConfigUtilsTest {
   private static final String DEFAULT_BUILD_USER = "DefaultBuildUser";
   private static final BuildCGroupResources DEFAULT_BUILD_BUILD_CGROUP_RESOURCES = new BuildCGroupResources(2, 2560);
   private static final long DEFAULT_BUILD_TIMEOUT = 1000L;
+  private static final long DEFAULT_CONTAINER_LAUNCH_TIMEOUT = 1000L;
   private static final GitInfo PRIMARY_BRANCH = GitInfo.fromString("git.example.com/TestOrg/repo.git#primary");
   private static final GitInfo SECONDARY_BRANCH = GitInfo.fromString("git.example.com/TestOrg/repo.git#secondary");
 
   private static final GitHubHelper gitHubHelper = mock(GitHubHelper.class);
   private static final BlazarConfiguration blazarConfiguration = mock(BlazarConfiguration.class);
-  private static final ExecutorConfiguration exexutorConfiguration = new ExecutorConfiguration(Optional.of(DEFAULT_BUILD_USER), Optional.of(DEFAULT_BUILD_BUILD_CGROUP_RESOURCES), Optional.of(DEFAULT_BUILD_TIMEOUT));
+  private static final ExecutorConfiguration exexutorConfiguration = new ExecutorConfiguration(Optional.of(DEFAULT_BUILD_USER), Optional.of(DEFAULT_BUILD_BUILD_CGROUP_RESOURCES), Optional.of(DEFAULT_BUILD_TIMEOUT), Optional.of(DEFAULT_CONTAINER_LAUNCH_TIMEOUT));
   private static final BuildConfigUtils configUtils = new BuildConfigUtils(blazarConfiguration, gitHubHelper);
 
   private static final BuildConfig primaryConfig = BuildConfig.newBuilder()


### PR DESCRIPTION
Blazar launches the container, and if the cluster says the attempted
launch was successful we wait for 5 minutes for the build executor to tell us
that it has started. If we have not heard from the executor in 5 minutes
we assume that the cluster states NOT_STARTED then we FAIL the build.

If the container state is UNKNOWN then we log an error letting the
maintainer know that Blazar could potentially be leaking containers
into the cluster the build was triggered in.