### PR TITLE
Remove mathjs dependency

### DIFF
--- a/BlazarUI/app/scripts/utils/progress.js
+++ b/BlazarUI/app/scripts/utils/progress.js
@@ -1,5 +1,31 @@
 import {filter} from 'underscore';
-import {std, mean} from 'mathjs';
+
+const sum = array => array.reduce((a, b) => a + b, 0);
+const mean = array => {
+  if (array.length === 0) {
+    throw new SyntaxError('Cannot compute mean of empty array.');
+  }
+
+  return sum(array) / array.length;
+};
+
+const variance = array => {
+  if (array.length === 0) {
+    throw new SyntaxError('Cannot compute variance of empty array.');
+  } else if (array.length === 1) {
+    return 0;
+  }
+
+  const thisMean = mean(array);
+  const result = sum(array.map(x => {
+    const diff = x - thisMean;
+    return diff * diff;
+  }));
+
+  return result / (array.length - 1);
+};
+
+const std = array => Math.sqrt(variance(array));
 
 function _filterOutliers(durations) {
   const values = durations.concat();

--- a/BlazarUI/package.json
+++ b/BlazarUI/package.json
@@ -38,7 +38,6 @@
     "js-cookie": "^2.0.3",
     "json-to-html": "^0.1.2",
     "keymirror": "^0.1.1",
-    "mathjs": "^2.4.0",
     "moment": "^2.10.3",
     "notifyjs": "^1.2.5",
     "object-assign": "^2.0.0",


### PR DESCRIPTION
GitHub warning about mathjs < 3.17.0 having a high severity security
vulnerability. Since we don't really need to import this library,
removing it instead.

Note: progress.js is legacy code that is not being imported into the
project right now.